### PR TITLE
Direction_id & Cross feed edges fixes

### DIFF
--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -75,14 +75,14 @@ def generate_cross_feed_edges(G,
         lat = float(row.stop_lat)
         lon = float(row.stop_lon)
         point = (lat, lon)
-        (nn, nn_dist) = get_nearest_node(node_df, point)
+        nearest_nodes = get_nearest_node(node_df, point, connection_threshold)
 
-        # Only generate a connector edge if it satisfies the
-        # meter distance threshold
-        if nn_dist < connection_threshold:
-            stop_ids.append(sid)
-            to_nodes.append(nn)
-            edge_costs.append(nn_dist)
+        # Iterate through series results and add to output
+        for node,distance in nearest_nodes.iteritems():
+          stop_ids.append(sid)
+          to_nodes.append(node)
+          edge_costs.append(distance)
+
 
     return pd.DataFrame({'stop_id': stop_ids,
                          'to_node': to_nodes,
@@ -149,7 +149,7 @@ def populate_graph(G: nx.MultiDiGraph,
 
         # Use the lookup table to get converted stop id name
         full_sid = sid_lookup[sid]
-
+        
         # Convert to km/hour
         kmph = (d / 1000) / walk_speed_kmph
 

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -27,10 +27,14 @@ def generate_wait_times(trips_and_stop_times: pd.DataFrame
 
         # Handle both inbound and outbound directions
         for direction in [0, 1]:
-            constraint_1 = (trips_and_stop_times.direction_id == direction)
-            constraint_2 = (trips_and_stop_times.stop_id == stop_id)
-            both_constraints = (constraint_1 & constraint_2)
-            direction_subset = trips_and_stop_times[both_constraints]
+            # Check if direction_id exists in source data
+            if 'direction_id' in trips_and_stop_times:
+              constraint_1 = (trips_and_stop_times.direction_id == direction)
+              constraint_2 = (trips_and_stop_times.stop_id == stop_id)
+              both_constraints = (constraint_1 & constraint_2)
+              direction_subset = trips_and_stop_times[both_constraints]
+            else:
+              direction_subset = trips_and_stop_times
 
             # Only run if each direction is contained
             # in the same trip id
@@ -55,9 +59,13 @@ def generate_all_observed_edge_costs(trips_and_stop_times: pd.DataFrame
         tst_sub = trips_and_stop_times[tst_mask]
 
         # Just in case both directions are under the same trip id
-        for direction in [0, 1]:
-            dir_mask = (tst_sub.direction_id == direction)
-            tst_sub_dir = tst_sub[dir_mask]
+        for direction in [1]:
+            # Check if direction_id exists in source data
+            if 'direction_id' in tst_sub:
+              dir_mask = (tst_sub.direction_id == direction)
+              tst_sub_dir = tst_sub[dir_mask]
+            else:
+              tst_sub_dir = tst_sub
 
             tst_sub_dir = tst_sub_dir.sort_values('stop_sequence')
             deps = tst_sub_dir.departure_time[:-1]

--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -39,7 +39,8 @@ def generate_graph_node_dataframe(G):
 
 
 def get_nearest_node(df_orig: pd.DataFrame,
-                     point: Tuple[float, float]):
+                     point: Tuple[float, float],
+                     connection_threshold):
     # This method breaks out a portion of a similar method from
     # OSMnx's get_nearest_node; source:
     #   https://github.com/gboeing/osmnx/blob/
@@ -69,8 +70,7 @@ def get_nearest_node(df_orig: pd.DataFrame,
                                  lng2=xs)
 
     # Calculate the final results to be returned
-    nearest_node = str(distances.idxmin())
-    nn_dist = distances.loc[nearest_node]
-
-    # Returna as tuple
-    return (nearest_node, nn_dist)
+    # Filter out nodes outside connection threshold and self (distance = 0)
+    nearest_nodes = distances[(distances > 0.0) & (distances < connection_threshold)]
+    # Return filtered series
+    return nearest_nodes


### PR DESCRIPTION
Hi,

first of all thanks a lot of your library. I started to use partridge couple weeks ago and also found it really nice to use. Naturally i started to need graphs for some queries soon enough and did try out Peartree. First problem which i have ran into was that my source feed (Prague DPP) didn't have direction_id and that didn't play well with Peartree. Then i started to play around with path finding in the graph and it didn't seem to work correctly. After some playing around i have isolated the problem to the cross feed edge generation implementation - the transfer edges weren't generated. I've tried it on acdata and my gtfs feed and the behaviour which i have seen is that there were no cross feed edges actually added but rather a self loop edge is added for each node. I came up with some fixes for that. 

I hope these fixes will help. Since this is my first github PR ever i hope i've done everything correctly.

Thanks!

Petr

 