### PR TITLE
Parameterize close-node edge creation on new nodes

### DIFF
--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -69,7 +69,8 @@ def generate_cross_feed_edges(G: nx.MultiDiGraph,
     node_df = generate_graph_node_dataframe(G)
 
     # Remove all nodes that are part of the new additions to the graph
-    node_df = node_df[~node_df.index.isin(exempt_nodes)]
+    if len(exempt_nodes) > 0:
+        node_df = node_df[~node_df.index.isin(exempt_nodes)]
 
     stop_ids = []
     to_nodes = []
@@ -242,7 +243,9 @@ def make_synthetic_system_network(
 
     # Generate cross feed edge values
     exempt_nodes = []
+    print('ayme?')
     if exempt_internal_edge_imputation:
+        print('using')
         exempt_nodes = sid_lookup.values()
     cross_feed_edges = generate_cross_feed_edges(G, nodes,
                                                  exempt_nodes,

--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -235,6 +235,9 @@ def make_synthetic_system_network(
         for key, val in sid_lookup_sub.items():
             sid_lookup[key] = val
 
+        # Update the nodes dataframe to include the graph name
+        nodes['stop_id'] = '{}_'.format(name) + nodes['stop_id']
+
         # Then add to the running tally of nodes
         if all_nodes is None:
             all_nodes = nodes.copy()
@@ -245,7 +248,7 @@ def make_synthetic_system_network(
     exempt_nodes = []
     if exempt_internal_edge_imputation:
         exempt_nodes = sid_lookup.values()
-    cross_feed_edges = generate_cross_feed_edges(G, nodes,
+    cross_feed_edges = generate_cross_feed_edges(G, all_nodes,
                                                  exempt_nodes,
                                                  connection_threshold)
     # Mutates the G network object

--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -56,6 +56,7 @@ def generate_summary_graph_elements(feed: ptg.gtfs.feed,
 
 
 def generate_cross_feed_edges(G: nx.MultiDiGraph,
+                              name: str,
                               stops_df: pd.DataFrame,
                               exempt_nodes: List[str],
                               connection_threshold: float) -> pd.DataFrame:
@@ -80,6 +81,7 @@ def generate_cross_feed_edges(G: nx.MultiDiGraph,
     #       be a way to condense these two steps well
     for i, row in stops_df.iterrows():
         sid = str(row.stop_id)
+        full_sid = nameify_stop_id(name, sid)
 
         # Ensure that each value is typed correctly prior to being
         # fed into the nearest node method
@@ -89,7 +91,7 @@ def generate_cross_feed_edges(G: nx.MultiDiGraph,
         nearest_nodes = get_nearest_nodes(node_df,
                                           point,
                                           connection_threshold,
-                                          exempt_id=sid)
+                                          exempt_id=full_sid)
 
         # Iterate through series results and add to output
         for node_id, dist_val in nearest_nodes.iteritems():
@@ -187,7 +189,7 @@ def populate_graph(G: nx.MultiDiGraph,
     exempt_nodes = []
     if exempt_internal_edge_imputation:
         exempt_nodes = sid_lookup.values()
-    cross_feed_edges = generate_cross_feed_edges(G, stops_df,
+    cross_feed_edges = generate_cross_feed_edges(G, name, stops_df,
                                                  exempt_nodes,
                                                  connection_threshold)
 
@@ -236,7 +238,7 @@ def make_synthetic_system_network(
             sid_lookup[key] = val
 
         # Update the nodes dataframe to include the graph name
-        nodes['stop_id'] = '{}_'.format(name) + nodes['stop_id']
+        # nodes['stop_id'] = '{}_'.format(name) + nodes['stop_id']
 
         # Then add to the running tally of nodes
         if all_nodes is None:
@@ -248,7 +250,7 @@ def make_synthetic_system_network(
     exempt_nodes = []
     if exempt_internal_edge_imputation:
         exempt_nodes = sid_lookup.values()
-    cross_feed_edges = generate_cross_feed_edges(G, all_nodes,
+    cross_feed_edges = generate_cross_feed_edges(G, name, all_nodes,
                                                  exempt_nodes,
                                                  connection_threshold)
     # Mutates the G network object

--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -237,9 +237,6 @@ def make_synthetic_system_network(
         for key, val in sid_lookup_sub.items():
             sid_lookup[key] = val
 
-        # Update the nodes dataframe to include the graph name
-        # nodes['stop_id'] = '{}_'.format(name) + nodes['stop_id']
-
         # Then add to the running tally of nodes
         if all_nodes is None:
             all_nodes = nodes.copy()

--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -171,7 +171,8 @@ def populate_graph(G: nx.MultiDiGraph,
                    wait_times_by_stop: pd.DataFrame,
                    summary_edge_costs: pd.DataFrame,
                    connection_threshold: Union[int, float],
-                   walk_speed_kmph: float=4.5):
+                   walk_speed_kmph: float=4.5,
+                   exempt_internal_edge_imputation: bool=False):
     # Generate a merge of the wait time data and the feed stops data that will
     # be used for both the addition of new stop nodes and the addition of
     # cross feed edges later on (that join one feeds stops to the other if
@@ -182,7 +183,9 @@ def populate_graph(G: nx.MultiDiGraph,
     sid_lookup = _add_nodes_and_edges(G, name, stops_df, summary_edge_costs)
 
     # Generate cross feed edge values
-    exempt_nodes = sid_lookup.values()
+    exempt_nodes = []
+    if exempt_internal_edge_imputation:
+        exempt_nodes = sid_lookup.values()
     cross_feed_edges = generate_cross_feed_edges(G, stops_df,
                                                  exempt_nodes,
                                                  connection_threshold)
@@ -198,7 +201,8 @@ def make_synthetic_system_network(
         name: str,
         reference_geojson: Dict,
         connection_threshold: Union[int, float],
-        walk_speed_kmph: float=4.5):
+        walk_speed_kmph: float=4.5,
+        exempt_internal_edge_imputation: bool=False):
     # Same as populate_graph, we use this dict to monitor the stop ids
     # that are created
     sid_lookup = {}
@@ -237,8 +241,10 @@ def make_synthetic_system_network(
             all_nodes = all_nodes.append(nodes)
 
     # Generate cross feed edge values
-    exempt_nodes = sid_lookup.values()
-    cross_feed_edges = generate_cross_feed_edges(G, all_nodes,
+    exempt_nodes = []
+    if exempt_internal_edge_imputation:
+        exempt_nodes = sid_lookup.values()
+    cross_feed_edges = generate_cross_feed_edges(G, nodes,
                                                  exempt_nodes,
                                                  connection_threshold)
     # Mutates the G network object

--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -243,9 +243,7 @@ def make_synthetic_system_network(
 
     # Generate cross feed edge values
     exempt_nodes = []
-    print('ayme?')
     if exempt_internal_edge_imputation:
-        print('using')
         exempt_nodes = sid_lookup.values()
     cross_feed_edges = generate_cross_feed_edges(G, nodes,
                                                  exempt_nodes,

--- a/peartree/paths.py
+++ b/peartree/paths.py
@@ -56,7 +56,8 @@ def load_feed_as_graph(feed: ptg.gtfs.feed,
                        existing_graph: nx.MultiDiGraph=None,
                        connection_threshold: float=50.0,
                        walk_speed_kmph: float=4.5,
-                       interpolate_times: bool=True):
+                       interpolate_times: bool=True,
+                       exempt_internal_edge_imputation: bool=True):
     """
     Convert a feed object into a NetworkX Graph, connect to an existing
     NetworkX graph if one is supplied
@@ -131,7 +132,8 @@ def load_feed_as_graph(feed: ptg.gtfs.feed,
                           wait_times_by_stop,
                           summary_edge_costs,
                           connection_threshold,
-                          walk_speed_kmph)
+                          walk_speed_kmph,
+                          exempt_internal_edge_imputation)
 
 
 def load_synthetic_network_as_graph(
@@ -139,7 +141,8 @@ def load_synthetic_network_as_graph(
         name: str=None,
         existing_graph: nx.MultiDiGraph=None,
         connection_threshold: float=50.0,
-        walk_speed_kmph: float=4.5):
+        walk_speed_kmph: float=4.5,
+        exempt_internal_edge_imputation: bool=False):
 
     # Generate a random name for name if it is None
     if not name:
@@ -164,4 +167,5 @@ def load_synthetic_network_as_graph(
         name,
         reference_geojson,
         connection_threshold,
-        walk_speed_kmph)
+        walk_speed_kmph,
+        exempt_internal_edge_imputation)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -174,4 +174,4 @@ def test_feed_to_graph_path():
     node_len_3 = len(G.nodes())
     edge_len_3 = len(G.edges())
     assert node_len_3 - node_len_2 == 74
-    assert edge_len_3 - edge_len_2 == 80
+    assert edge_len_3 - edge_len_2 == 151

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -174,4 +174,4 @@ def test_feed_to_graph_path():
     node_len_3 = len(G.nodes())
     edge_len_3 = len(G.edges())
     assert node_len_3 - node_len_2 == 74
-    assert edge_len_3 - edge_len_2 == 151
+    assert edge_len_3 - edge_len_2 == 80


### PR DESCRIPTION
When we add a 2nd (3rd, 4th...) GTFS to an existing graph, we attempt to find connections between the two systems that are close and make them low/no-cost edge connectors.

This adds a parameter to make such it optional to exempt the new nodes from this step. Typically, you would do this with schedule data as the GTFS schedule should itself have the connections built in.

BUT when building stops and edges from a "synthetic" path, we want to make sure that we also create edges between the new paths created since they will not be naturally synced with each other (or each direction, for that matter).