### PR TITLE
[notebook] Update dev dependencies for make notebook

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ flake8
 coverage
 pytest
 pytest-runner
-jupyter==1.0.0
-jupyter-client==5.1.0
-jupyter-console==5.2.0
-jupyter-core==4.4.0
+jupyter>=1.0.0
+jupyter-client>=5.1.0
+jupyter-console>=5.2.0
+jupyter-core>=4.4.0


### PR DESCRIPTION
Fixes https://github.com/kuanb/peartree/issues/37

Looks like there were some updates to the Jupyter client that caused that break to occur. Not sure exactly what, but just updated the dev dependencies to use the latest Jupyter libraries in the hopes that this will keep the notebook configuration up to date with the latest bug fixes (and, perhaps, also the latest bugs :) ).