### PR TITLE
Negative edge cost fallback, tag mode

### DIFF
--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -134,7 +134,7 @@ def _add_cross_feed_edges(G: nx.MultiDiGraph,
         in_seconds = kmph * 60 * 60
 
         # And then add it to the graph
-        G.add_edge(full_sid, to, length=in_seconds)
+        G.add_edge(full_sid, to, length=in_seconds, type='walk')
 
 
 def _add_nodes_and_edges(G: nx.MultiDiGraph,
@@ -162,12 +162,12 @@ def _add_nodes_and_edges(G: nx.MultiDiGraph,
     for i, row in summary_edge_costs.iterrows():
         sid_fr = nameify_stop_id(name, row.from_stop_id)
         sid_to = nameify_stop_id(name, row.to_stop_id)
-        G.add_edge(sid_fr, sid_to, length=row.edge_cost)
+        G.add_edge(sid_fr, sid_to, length=row.edge_cost, type='transit')
 
         # If want to add both directions in this step, we can
         # by reversing the to/from node order on edge
         if bidirectional:
-            G.add_edge(sid_to, sid_fr, length=row.edge_cost)
+            G.add_edge(sid_to, sid_fr, length=row.edge_cost, type='transit')
 
 
     return sid_lookup

--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -134,7 +134,7 @@ def _add_cross_feed_edges(G: nx.MultiDiGraph,
         in_seconds = kmph * 60 * 60
 
         # And then add it to the graph
-        G.add_edge(full_sid, to, length=in_seconds, type='walk')
+        G.add_edge(full_sid, to, length=in_seconds, mode='walk')
 
 
 def _add_nodes_and_edges(G: nx.MultiDiGraph,
@@ -162,12 +162,12 @@ def _add_nodes_and_edges(G: nx.MultiDiGraph,
     for i, row in summary_edge_costs.iterrows():
         sid_fr = nameify_stop_id(name, row.from_stop_id)
         sid_to = nameify_stop_id(name, row.to_stop_id)
-        G.add_edge(sid_fr, sid_to, length=row.edge_cost, type='transit')
+        G.add_edge(sid_fr, sid_to, length=row.edge_cost, mode='transit')
 
         # If want to add both directions in this step, we can
         # by reversing the to/from node order on edge
         if bidirectional:
-            G.add_edge(sid_to, sid_fr, length=row.edge_cost, type='transit')
+            G.add_edge(sid_to, sid_fr, length=row.edge_cost, mode='transit')
 
 
     return sid_lookup

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -90,6 +90,16 @@ def generate_all_observed_edge_costs(trips_and_stop_times: pd.DataFrame
             # Use .values to strip existing indices
             edge_costs = np.subtract(arrs.values, deps.values)
 
+            # TODO(kuanb): Negative values can result here!
+            # HACK: There are times when the arrival and departure data
+            #       are "out of order" which results in negative values.
+            #       From the values I've looked at, these are edge cases
+            #       that have to do with start/end overlaps. I don't have
+            #       a good answer for dealing with these but, since they
+            #       are possible noise, they can be override by taking
+            #       their absolute value.
+            edge_costs = np.absolute(edge_costs)
+
             # Add each resulting list to the running array totals
             all_edge_costs += list(edge_costs)
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -135,6 +135,34 @@ def test_synthetic_network():
     assert nx.is_strongly_connected(G2)
 
 
+def test_feed_edge_types():
+    path = fixture('samtrans-2017-11-28.zip')
+    feed = get_representative_feed(path)
+    G1 = load_feed_as_graph(feed, start, end)
+
+    # In the base case, all should be transit
+    for _, _, e in G1.edges(data=True):
+        assert e['mode'] == 'transit'
+
+    # Now perform a second check where we impute walk edges
+    G2 = pt.load_feed_as_graph(
+        feed, start, end, exempt_internal_edge_imputation=False)
+
+    # Count the number of edge types by mode, which should now
+    # include walk edges as well
+    transit_count = 0
+    walk_count = 0
+    for _, _, e in G.edges(data=True):
+        if e['mode'] == 'transit':
+            transit_count += 1
+        if e['mode'] == 'walk':
+            walk_count += 1
+
+    # And make sure the correct number were made
+    assert transit_count == 1940
+    assert walk_count == 864
+
+
 def test_feed_to_graph_path():
     path_1 = fixture('caltrain-2017-07-24.zip')
     feed_1 = get_representative_feed(path_1)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -155,7 +155,7 @@ def test_feed_edge_types():
     # include walk edges as well
     transit_count = 0
     walk_count = 0
-    for _, _, e in G.edges(data=True):
+    for _, _, e in G2.edges(data=True):
         if e['mode'] == 'transit':
             transit_count += 1
         if e['mode'] == 'walk':

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -138,6 +138,9 @@ def test_synthetic_network():
 def test_feed_edge_types():
     path = fixture('samtrans-2017-11-28.zip')
     feed = get_representative_feed(path)
+
+    start = 7 * 60 * 60
+    end = 10 * 60 * 60
     G1 = load_feed_as_graph(feed, start, end)
 
     # In the base case, all should be transit

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -148,7 +148,7 @@ def test_feed_edge_types():
         assert e['mode'] == 'transit'
 
     # Now perform a second check where we impute walk edges
-    G2 = pt.load_feed_as_graph(
+    G2 = load_feed_as_graph(
         feed, start, end, exempt_internal_edge_imputation=False)
 
     # Count the number of edge types by mode, which should now


### PR DESCRIPTION
Two items in this PR:
- We take the absolute value of all edges as there are currently negative edges being calculated
- Note this is a fallback since these are "edge cases" in that they have to do with schedule data being staggered incorrectly, so we are just "wrapping around" the start/end of the schedule
- Adding a tag for walk segments when they are added to make it easy to identify walk transfers when they are generated