### PR TITLE
Avoid triggering matplotlib use Agg warnings

### DIFF
--- a/peartree/plot.py
+++ b/peartree/plot.py
@@ -1,9 +1,15 @@
+import os
+
 import matplotlib
 import networkx as nx
 import osmnx as ox
 
-# Force matplotlib to not use any Xwindows backend.
-matplotlib.use('Agg')
+# Check if the display has already been set and, if not...
+cmd = 'python -c "import matplotlib.pyplot as plt;plt.figure()"'
+r = os.system(cmd)
+if r != 0:
+    # Force matplotlib to not use any Xwindows backend
+    matplotlib.use('Agg')
 
 
 def generate_plot(G: nx.MultiDiGraph):

--- a/peartree/plot.py
+++ b/peartree/plot.py
@@ -6,8 +6,8 @@ import osmnx as ox
 
 # Check if the display has already been set and, if not...
 cmd = 'python -c "import matplotlib.pyplot as plt;plt.figure()"'
-r = os.system(cmd)
-if r != 0:
+check = os.system(cmd)
+if check != 0:
     # Force matplotlib to not use any Xwindows backend
     matplotlib.use('Agg')
 


### PR DESCRIPTION
Checks if display is available first, before attempting mpl's `.use('Agg')`