### PR TITLE
Coalesce graph operation

### DIFF
--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -145,3 +145,75 @@ def reproject(G: nx.MultiDiGraph, to_epsg: int=2163) -> nx.MultiDiGraph:
 
     # Return the reprojected copy
     return G
+
+
+def coalesce(G: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
+    # Avoid upstream mutation of the graph
+    G = G.copy()
+    graph_name = G.name
+
+    # Extract all x, y values
+    grouped = {}
+    for i, node in G.nodes(data=True):
+        x = (round(node['x'] / resolution) * resolution)
+        y = (round(node['y'] / resolution) * resolution)
+
+        # Build the dictionary as needed
+        if x not in grouped:
+            grouped[x] = {}
+        if y not in grouped[x]:
+            grouped[x][y] = []
+
+        # Append each node under its approx. area grouping
+        grouped[x][y].append(i)
+
+    # Generate a series of reference dictionaries that allow us
+    # to assign a new node name to each grouping of nodes
+    counter = 0
+    new_node_coords = {}
+    lookup = {}
+    for x in grouped:
+        for y in grouped[x]:
+            new_node_name = '{}_{}'.format(graph_name, counter)
+            new_node_coords[new_node_name] = {'x': x, 'y': y}
+            for n in grouped[x][y]:
+                lookup[n] = new_node_name
+            counter += 1
+
+    # Recast the lookup crosswalk as a series for convenience
+    reference = pd.Series(lookup)
+
+    # Get the average boarding cost for each node grouping
+    for nni in new_node_coords:
+        boarding_costs = []
+        g_nodes = reference.loc[reference == nni].index.values
+        for i in g_nodes:
+            bc = G.nodes[i]['boarding_cost']
+            boarding_costs.append(bc)
+        avg_bc = np.array(boarding_costs).mean()
+        new_node_coords[nni]['boarding_cost'] = avg_bc
+
+    # Create a list of replacement edges
+    edges_to_add = []
+    for n1, n2, edge in G.edges(data=True):
+        edges_to_add.append((reference[n1], reference[n2], edge))
+
+    # Add the new edges
+    for n1, n2, edge in edges_to_add:
+        # But avoid edges that now connect to the same node
+        if not n1 == n2:
+            G.add_edge(n1, n2, length=edge['length'], mode=edge['mode'])
+
+    # Now we can remove all edges and nodes that predated the
+    # coalescing operations
+    for n in reference.index:
+        # Note that this will also drop all edges
+        G.remove_node(n)
+
+    # Also make sure to update the new nodes with their summary
+    # stats and locational data
+    for i, node in new_node_coords.items():
+        for key in node:
+            G.nodes[i][key] = node[key]
+
+    return G

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -1,6 +1,13 @@
 import networkx as nx
 import pytest
-from peartree.toolkit import reproject
+from peartree.toolkit import coalesce, reproject
+
+
+def _assert_dict(got, want):
+    for key in want:
+        if not got[key] == want[key]:
+            print(got)
+        assert got[key] == want[key]
 
 
 def test_feed_to_graph_plot():
@@ -36,3 +43,31 @@ def test_feed_to_graph_plot():
         a = (y == pytest.approx(expected_ys[0], abs=0.01))
         b = (y == pytest.approx(expected_ys[1], abs=0.01))
         assert (a or b)
+
+
+def test_coalesce_operation():
+    # Create a simple graph
+    G = nx.Graph(crs={'init': 'epsg:4326', 'no_defs': True}, name='foo')
+
+    # And add two nodes to it
+    G.add_node('a', x=-122.2729918, y=37.7688136, boarding_cost=10)
+    G.add_node('b', x=-122.2711039, y=37.7660709, boarding_cost=15)
+    G.add_node('c', x=-122.2711038, y=37.7660708, boarding_cost=12)
+    G.add_edge('a', 'b', length=10, mode='transit')
+    G.add_edge('b', 'c', length=1, mode='walk')
+
+    G2 = reproject(G)
+
+    G2c = coalesce(G2, 200)
+    G2c.nodes(data=True), G2c.edges(data=True)
+
+    _assert_dict(G2c.nodes['foo_0'], {
+                 'x': -1933000, 'y': -543000, 'boarding_cost': 10.0})
+    _assert_dict(G2c.nodes['foo_1'], {
+                 'x': -1932800, 'y': -543400, 'boarding_cost': 13.5})
+
+    all_edges = list(G2c.edges(data=True))
+    assert len(all_edges) == 1
+
+    # Make sure that the one edge came out as expected
+    _assert_dict(all_edges[0][2], {'length': 10, 'mode': 'transit'})


### PR DESCRIPTION
Fixes https://github.com/kuanb/peartree/issues/42

API: ```Gc = pt.coalesce(G, 400)```

Where first arg is the Graph, and second is the threshold in the units currently relevant to the graph's set CRS.

![compare](https://user-images.githubusercontent.com/6053396/37562298-d99985b2-2a9f-11e8-9a25-b0777503c733.gif)