### PR TITLE
[performance] WIP Parallelization of route edge and wait costing iteration

### DIFF
--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -333,6 +333,8 @@ def generate_edge_and_wait_values(
     for i, route in feed.routes.iterrows():
         (tst_sub,
          edge_costs) = _process_route_edges_and_wait_times(route,
+                                                           target_time_start,
+                                                           target_time_end,
                                                            ftrips,
                                                            stop_times,
                                                            all_stops)
@@ -354,6 +356,8 @@ def generate_edge_and_wait_values(
 
 def _process_route_edges_and_wait_times(
         route: pd.Series,
+        target_time_start: int,
+        target_time_end: int,
         ftrips: pd.DataFrame,
         stop_times: pd.DataFrame,
         all_stops: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -337,6 +337,12 @@ def generate_edge_and_wait_values(
     log('Running route-wise wait and edge costing using '
         'dask distributed client:\n{}.'.format(client))
 
+    # Similarly, convert all reference dataframes to dask equivalents
+    # TODO: Specify partitions (how to? allow user input? programmatic?)
+    ftrips_ddf = dask.datafrom_pandas(ftrips)
+    stop_times_ddf = dask.datafrom_pandas(stop_times)
+    all_stops_ddf = dask.datafrom_pandas(all_stops)
+
     array_bag = {
         'all_edge_costs': [],
         'all_wait_times': []
@@ -351,9 +357,9 @@ def generate_edge_and_wait_values(
                 route_id,
                 target_time_start,
                 target_time_end,
-                ftrips,
-                stop_times,
-                all_stops)
+                ftrips_ddf,
+                stop_times_ddf,
+                all_stops_ddf)
 
         # Add to the running total for wait times in this feed subset
         array_bag['all_wait_times'].append(tst_sub)
@@ -386,9 +392,9 @@ def process_route_edges_and_wait_times(
         route_id: str,
         target_time_start: int,
         target_time_end: int,
-        ftrips: pd.DataFrame,
-        stop_times: pd.DataFrame,
-        all_stops: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
+        ftrips: dask.dataframe,
+        stop_times: dask.dataframe,
+        all_stops: dask.dataframe) -> Tuple[dask.dataframe, dask.dataframe]:
     log('Processing on route {}.'.format(route_id))
 
     # Get all the subset of trips that are related to this route

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -324,6 +324,9 @@ def generate_edge_and_wait_values(
 
     all_edge_costs = None
     all_wait_times = None
+
+    # Note: Each route can be evaluated in isolation from other routes;
+    #       thus, this operation is embarassingly parallelizable
     for i, route in feed.routes.iterrows():
         log('Processing on route {}.'.format(route.route_id))
 

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -342,10 +342,13 @@ def generate_edge_and_wait_values(
         'all_wait_times': []
     }
     for i, route in feed.routes.iterrows():
+        # For each, convert related components to dask and dask-safe variants
+        route_id = route.to_dict()['route_id']
+
         # Queue up, with a delayed action
         (tst_sub, edge_costs) = dask.delayed(
             process_route_edges_and_wait_times)(
-                route,
+                route_id,
                 target_time_start,
                 target_time_end,
                 ftrips,
@@ -380,16 +383,16 @@ def generate_edge_and_wait_values(
 
 @dask.delayed
 def process_route_edges_and_wait_times(
-        route: pd.Series,
+        route_id: str,
         target_time_start: int,
         target_time_end: int,
         ftrips: pd.DataFrame,
         stop_times: pd.DataFrame,
         all_stops: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    log('Processing on route {}.'.format(route.route_id))
+    log('Processing on route {}.'.format(route_id))
 
     # Get all the subset of trips that are related to this route
-    trips = ftrips.loc[route.route_id]
+    trips = ftrips.loc[route_id]
 
     # Pandas will try and make returned result a Series if there
     # is only one result - prevent this from happening

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -368,6 +368,9 @@ def generate_edge_and_wait_values(
     log('Wait and edges succesfully computed via '
         'dask distributed: {}s.'.format(elapsed))
 
+    # Close out the cluster
+    client.close()
+
     all_wait_times_df = pd.DataFrame(array_bag['all_wait_times'],
         columns=['stop_id', 'wait_dir_0', 'wait_dir_1'])
     all_edge_costs_df = pd.DataFrame(array_bag['all_edge_costs'],

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -335,7 +335,7 @@ def generate_edge_and_wait_values(
     cluster = LocalCluster()
     client = Client(cluster)
     log('Running route-wise wait and edge costing using '
-        'dask distributed client: {}.'.format(route.route_id))
+        'dask distributed client: {}.'.format(client))
 
     array_bag = {
         'all_edge_costs': [],

--- a/peartree/utilities.py
+++ b/peartree/utilities.py
@@ -1,7 +1,6 @@
 import datetime as dt
 import logging as lg
 import os
-import sys
 import unicodedata
 
 from . import settings
@@ -97,12 +96,6 @@ def log(message: str, level=None, name=None, filename=None):
     # If logging to console is turned on, convert message to ascii and print to
     # the console
     if settings.log_console:
-        # Capture current stdout, then switch it to the console, print the
-        # message, then switch back to what had been the stdout. this prevents
-        # logging to notebook - instead, it goes to console
-        standard_out = sys.stdout
-        sys.stdout = sys.__stdout__
-
         # Convert message to ascii for console display so it doesn't break
         # windows terminals
         str_msg = make_str(message)
@@ -110,4 +103,3 @@ def log(message: str, level=None, name=None, filename=None):
         encoded = normalized.encode('ascii', errors='replace')
         decoded = encoded.decode()
         print(decoded)
-        sys.stdout = standard_out

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+dask==0.17.2
+distributed==1.21.4
 fiona==1.6.1
 networkx>=2.0
 osmnx==0.6


### PR DESCRIPTION
Partially (incrementally) addressing issue https://github.com/kuanb/peartree/issues/12

Parallelizes target route processing operation `process_route_edges_and_wait_times` via dask distributed which allows for modular parallelization architecture which in the future could leverage external resources (useful for large graphs, tethering together whole regions, etc.).

TODO: Address GIL locking pandas operations triggering:
```
distributed.core - WARNING - Event loop was unresponsive in Scheduler for 1.18s.  This is often caused by long-running GIL-holding functions or moving large chunks of data. This can cause timeouts and instability.
```

The solution here will be to also distribute sum of the subroutines being performed within each route processor.

Ensure dictionary roll up (`array_bag`) working as intended. Currently encountering an unintended `NameError`.