### PR TITLE
[performance] WIP Parallelization of route edge and wait costing iteration

### DIFF
--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -34,12 +34,14 @@ def nameify_stop_id(name, sid):
 def generate_summary_graph_elements(feed: ptg.gtfs.feed,
                                     target_time_start: int,
                                     target_time_end: int,
-                                    interpolate_times: bool):
+                                    interpolate_times: bool,
+                                    use_multiprocessing: bool):
     (all_edge_costs,
      all_wait_times) = generate_edge_and_wait_values(feed,
                                                      target_time_start,
                                                      target_time_end,
-                                                     interpolate_times)
+                                                     interpolate_times,
+                                                     use_multiprocessing)
 
     # Handle if there are no valid edges returned (or wait times)
     if all_edge_costs is None or len(all_edge_costs) == 0:

--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -153,7 +153,6 @@ def _add_nodes_and_edges(G: nx.MultiDiGraph,
 
         # Add to the lookup crosswalk dictionary
         sid_lookup[sid] = full_sid
-
         G.add_node(full_sid,
                    boarding_cost=row.avg_cost,
                    y=row.stop_lat,

--- a/peartree/paths.py
+++ b/peartree/paths.py
@@ -57,7 +57,8 @@ def load_feed_as_graph(feed: ptg.gtfs.feed,
                        connection_threshold: float=50.0,
                        walk_speed_kmph: float=4.5,
                        interpolate_times: bool=True,
-                       impute_walk_transfers: bool=False):
+                       impute_walk_transfers: bool=False,
+                       use_multiprocessing: bool=True):
     """
     Convert a feed object into a NetworkX Graph, connect to an existing
     NetworkX graph if one is supplied
@@ -96,6 +97,9 @@ def load_feed_as_graph(feed: ptg.gtfs.feed,
     impute_walk_transfers : bool
         A flag to indicate whether to add in walk connections between nodes
         that are close enough, as measured using connection_trheshold
+    use_multiprocessing: bool
+        A flag to indicate whether or not to leverage multiprocessing where
+        available to attempt to speed up trivially parallelizable operations.
 
     Returns
     -------
@@ -120,7 +124,8 @@ def load_feed_as_graph(feed: ptg.gtfs.feed,
      wait_times_by_stop) = generate_summary_graph_elements(feed,
                                                            start_time,
                                                            end_time,
-                                                           interpolate_times)
+                                                           interpolate_times,
+                                                           use_multiprocessing)
 
     # This is a flag used to check if we need to run any additional steps
     # after the feed is returned to ensure that new nodes and edge can connect

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -330,7 +330,7 @@ def generate_edge_and_wait_values(
         stop_times,
         feed.stops.copy())
 
-    route_id_list = dbag.from_sequence(feed.routes.route_id.head())
+    route_id_list = dbag.from_sequence(feed.routes.route_id)
     res = route_id_list.map(route_analyzer.generate_route_costs).compute()
 
     all_edge_costs = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+dask==0.17.2
+distributed==1.21.4
 fiona==1.6.1
 networkx>=2.0
 osmnx==0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-dask==0.17.2
-distributed==1.21.4
 fiona==1.6.1
 networkx>=2.0
 osmnx==0.6

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -24,52 +24,55 @@ def test_generate_summary_graph_elements():
     interpolate_times = True
     use_multiprocessing = True
 
-    (summary_edge_costs,
-     wait_times_by_stop) = generate_summary_graph_elements(feed_1,
-                                                           start,
-                                                           end,
-                                                           interpolate_times,
-                                                           use_multiprocessing)
+    # Make sure everything works the same with both multiprocessing on/off
+    for use_multiprocessing in [True, False]:
+        (summary_edge_costs,
+         wait_times_by_stop) = generate_summary_graph_elements(
+            feed_1,
+            start,
+            end,
+            interpolate_times,
+            use_multiprocessing)
 
-    # Ensure that the summary edge cost dataframe looks as it should
-    ec_cols = ['edge_cost', 'from_stop_id', 'to_stop_id']
-    for c in ec_cols:
-        assert c in summary_edge_costs.columns
+        # Ensure that the summary edge cost dataframe looks as it should
+        ec_cols = ['edge_cost', 'from_stop_id', 'to_stop_id']
+        for c in ec_cols:
+            assert c in summary_edge_costs.columns
 
-    # Make sure that all edges are unique - there are no duplicated
-    # in the returned edge dataframe (each should be its own summary)
-    f = summary_edge_costs.from_stop_id
-    t = summary_edge_costs.to_stop_id
-    z = list(zip(f, t))
-    assert len(list(set(z))) == len(z)
+        # Make sure that all edges are unique - there are no duplicated
+        # in the returned edge dataframe (each should be its own summary)
+        f = summary_edge_costs.from_stop_id
+        t = summary_edge_costs.to_stop_id
+        z = list(zip(f, t))
+        assert len(list(set(z))) == len(z)
 
-    # Ensure that the wait times dataframe looks as it should
-    wt_cols = ['avg_cost', 'stop_id']
-    for c in wt_cols:
-        assert c in wait_times_by_stop.columns
+        # Ensure that the wait times dataframe looks as it should
+        wt_cols = ['avg_cost', 'stop_id']
+        for c in wt_cols:
+            assert c in wait_times_by_stop.columns
 
-    # Sanity check edge costs
-    mask = (wait_times_by_stop.avg_cost < 0)
-    assert len(wait_times_by_stop[mask]) == 0
+        # Sanity check edge costs
+        mask = (wait_times_by_stop.avg_cost < 0)
+        assert len(wait_times_by_stop[mask]) == 0
 
-    # Make sure that there are stop ids unique
-    u = wait_times_by_stop.stop_id.unique()
-    assert len(u) == len(wait_times_by_stop)
+        # Make sure that there are stop ids unique
+        u = wait_times_by_stop.stop_id.unique()
+        assert len(u) == len(wait_times_by_stop)
 
-    # Another sanity check, we should be sure that the resulting
-    # edges list captures all the stops that were assigned null
-    # values in the fixture dataset were assigned a linearly imputed
-    # arrival and departure time and thus preserved as a stop
-    # in the edge list
+        # Another sanity check, we should be sure that the resulting
+        # edges list captures all the stops that were assigned null
+        # values in the fixture dataset were assigned a linearly imputed
+        # arrival and departure time and thus preserved as a stop
+        # in the edge list
 
-    # First get the null times mask
-    null_times = feed_1.stop_times.departure_time.isnull()
-    # And identify all unique stops from the original feed
-    null_stop_ids = feed_1.stop_times[null_times].stop_id.unique()
+        # First get the null times mask
+        null_times = feed_1.stop_times.departure_time.isnull()
+        # And identify all unique stops from the original feed
+        null_stop_ids = feed_1.stop_times[null_times].stop_id.unique()
 
-    # Now let's take the list of these null stop ids and extract
-    # all the ones from that list in the summary edge dataframe
-    mask = summary_edge_costs.from_stop_id.isin(null_stop_ids)
-    # And now we can get the stop ids out from this list
-    preserved_from_nulls = summary_edge_costs.from_stop_id[mask].unique()
-    assert len(preserved_from_nulls) == 205
+        # Now let's take the list of these null stop ids and extract
+        # all the ones from that list in the summary edge dataframe
+        mask = summary_edge_costs.from_stop_id.isin(null_stop_ids)
+        # And now we can get the stop ids out from this list
+        preserved_from_nulls = summary_edge_costs.from_stop_id[mask].unique()
+        assert len(preserved_from_nulls) == 205

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -22,12 +22,14 @@ def test_generate_summary_graph_elements():
     start = 7 * 60 * 60
     end = 10 * 60 * 60
     interpolate_times = True
+    use_multiprocessing = True
 
     (summary_edge_costs,
      wait_times_by_stop) = generate_summary_graph_elements(feed_1,
                                                            start,
                                                            end,
-                                                           interpolate_times)
+                                                           interpolate_times,
+                                                           use_multiprocessing)
 
     # Ensure that the summary edge cost dataframe looks as it should
     ec_cols = ['edge_cost', 'from_stop_id', 'to_stop_id']

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -22,7 +22,6 @@ def test_generate_summary_graph_elements():
     start = 7 * 60 * 60
     end = 10 * 60 * 60
     interpolate_times = True
-    use_multiprocessing = True
 
     # Make sure everything works the same with both multiprocessing on/off
     for use_multiprocessing in [True, False]:

--- a/tests/test_graph_assembly.py
+++ b/tests/test_graph_assembly.py
@@ -18,6 +18,7 @@ def test_feed_to_graph_performance():
     start = 7 * 60 * 60
     end = 10 * 60 * 60
     interpolate_times = True
+    use_multiprocessing = True
 
     print('Running time profiles on each major '
           'function in graph generation workflow')
@@ -36,7 +37,8 @@ def test_feed_to_graph_performance():
      all_wait_times) = generate_edge_and_wait_values(feed,
                                                      start,
                                                      end,
-                                                     interpolate_times)
+                                                     interpolate_times,
+                                                     use_multiprocessing)
     elapsed = round(time() - a, 2)
     print('Perf of generate_edge_and_wait_values: {}s'.format(elapsed))
 


### PR DESCRIPTION
This replaced work on https://github.com/kuanb/peartree/pull/51/files

From the previous PR:
Partially (incrementally) addressing issue #12

Parallelizes target route processing operation process_route_edges_and_wait_times via dask distributed which allows for modular parallelization architecture which in the future could leverage external resources (useful for large graphs, tethering together whole regions, etc.).

------

Updates unique to this new PR:

Using multiprocessing, _not_ Dask, for now. Change is incremental.

------
OLD:

Going with a Dask Bag for now. Keeping it simple for now, and can improve later.

Results from a quick test with AC Transit and the new system:

With `interpolate_times` set to `False`:
Without Dask (original method):
```
CPU times: user 40.4 s, sys: 920 ms, total: 41.3 s
Wall time: 41 s
```

With Dask:
```
CPU times: user 13.2 s, sys: 530 ms, total: 13.7 s
Wall time: 14.6 s
```

For reference, this is doing just the first 5 routes:
Without Dask:
```
CPU times: user 6.15 s, sys: 140 ms, total: 6.29 s
Wall time: 6.34 s
```

With Dask:
```
CPU times: user 13 s, sys: 440 ms, total: 13.5 s
Wall time: 14.3 s
```

Even more dramatic is when you set the time interpolation to `True`:
Without Dask: 3min 55s
With Dask: 1min 17s

From this, the initial cost of about 14.3 seconds can be seen to initialize the various Dask configurations to enable the parallelization. The upside is the significantly reduced marginal cost of each additional unique route.

Of course, a lot of this matters on the machine you are running. Allowing for access to Dask Distributed's Client will be next to do, which will enable utilizing external resources.