### PR TITLE
[performance] cProfile and visualize library performance with a single script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 dist/
 peartree.egg-info/
 notebooks/
+performance/cprof-output.py

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ docker-clean:
 
 cprofile:
 	pip install snakeviz
-	python -m cProfile -o /code/profile/cprof-output.py /code/performance/run_etl.py
-	snakeviz /code/profile/cprof-output.py
+	python -m cProfile -o /code/performance/cprof-output.py /code/performance/run_etl.py
+	snakeviz /code/performance/cprof-output.py
 
 install-graph-tool:
 	sed -i -e '$$a\

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-test:
+gtest:
 	PYTHONPATH=. MPLBACKEND="agg" coverage run --source peartree -m py.test --verbose
 
 performance:
@@ -16,8 +16,8 @@ docker-clean:
 
 cprofile:
 	pip install snakeviz
-	python -m cProfile -o /code/performance/cprof-output.py /code/performance/run_etl.py
-	snakeviz /code/performance/cprof-output.py
+	python -m cProfile -o performance/cprof-output.py performance/run_etl.py
+	snakeviz performance/cprof-output.py
 
 install-graph-tool:
 	sed -i -e '$$a\

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,27 @@
 test:
-	PYTHONPATH=. MPLBACKEND="agg" coverage run --source peartree -m py.test --verbose
+    PYTHONPATH=. MPLBACKEND="agg" coverage run --source peartree -m py.test --verbose
 
 performance:
-	PYTHONPATH=. MPLBACKEND="agg" pytest profiler/test_graph_assembly.py -s
+    PYTHONPATH=. MPLBACKEND="agg" pytest profiler/test_graph_assembly.py -s
 
 notebook:
-	docker-compose build
-	mkdir -p ./notebooks
-	docker-compose up notebook
+    docker-compose build
+    mkdir -p ./notebooks
+    docker-compose up notebook
 
 docker-clean:
-	docker network prune --force
-	docker volume prune --force
-	docker image prune --force
+    docker network prune --force
+    docker volume prune --force
+    docker image prune --force
+
+cprofile:
+    pip install snakeviz
+    python -m cProfile -o /code/profile/cprof-output.py /code/performance/run_etl.py
+    snakeviz /code/profile/cprof-output.py
 
 install-graph-tool:
-	sed -i -e '$$a\
-	deb http://downloads.skewed.de/apt/stretch stretch main\
-	deb-src http://downloads.skewed.de/apt/stretch stretch main' /etc/apt/sources.list && \
-	apt-get update && \
-	apt-get install python3-graph-tool
+    sed -i -e '$$a\
+    deb http://downloads.skewed.de/apt/stretch stretch main\
+    deb-src http://downloads.skewed.de/apt/stretch stretch main' /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install python3-graph-tool

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,27 @@
 test:
-    PYTHONPATH=. MPLBACKEND="agg" coverage run --source peartree -m py.test --verbose
+	PYTHONPATH=. MPLBACKEND="agg" coverage run --source peartree -m py.test --verbose
 
 performance:
-    PYTHONPATH=. MPLBACKEND="agg" pytest profiler/test_graph_assembly.py -s
+	PYTHONPATH=. MPLBACKEND="agg" pytest profiler/test_graph_assembly.py -s
 
 notebook:
-    docker-compose build
-    mkdir -p ./notebooks
-    docker-compose up notebook
+	docker-compose build
+	mkdir -p ./notebooks
+	docker-compose up notebook
 
 docker-clean:
-    docker network prune --force
-    docker volume prune --force
-    docker image prune --force
+	docker network prune --force
+	docker volume prune --force
+	docker image prune --force
 
 cprofile:
-    pip install snakeviz
-    python -m cProfile -o /code/profile/cprof-output.py /code/performance/run_etl.py
-    snakeviz /code/profile/cprof-output.py
+	pip install snakeviz
+	python -m cProfile -o /code/profile/cprof-output.py /code/performance/run_etl.py
+	snakeviz /code/profile/cprof-output.py
 
 install-graph-tool:
-    sed -i -e '$$a\
-    deb http://downloads.skewed.de/apt/stretch stretch main\
-    deb-src http://downloads.skewed.de/apt/stretch stretch main' /etc/apt/sources.list && \
-    apt-get update && \
-    apt-get install python3-graph-tool
+	sed -i -e '$$a\
+	deb http://downloads.skewed.de/apt/stretch stretch main\
+	deb-src http://downloads.skewed.de/apt/stretch stretch main' /etc/apt/sources.list && \
+	apt-get update && \
+	apt-get install python3-graph-tool

--- a/peartree/utilities.py
+++ b/peartree/utilities.py
@@ -54,7 +54,7 @@ def config(log_console=settings.log_console):
 
     # if logging is turned on, log that we are configured
     if settings.log_file or settings.log_console:
-        log('Configured osmnx')
+        log('Configured peartree')
 
 
 def make_str(value):

--- a/performance/run_etl.py
+++ b/performance/run_etl.py
@@ -1,0 +1,31 @@
+import os
+import tempfile
+from urllib.request import urlopen
+
+import partridge as ptg
+import peartree as pt
+
+pt.utilities.config(log_console=True)
+
+if __name__ == '__main__':
+    '''
+    Run from command line via:
+    python -m cProfile -o profile/cprof-output.py performance/run_etl.py
+
+    And visualize via:
+    snakeviz profile/cprof-output.py
+    '''
+    url_path = 'http://www.actransit.org/wp-content/uploads/GTFS_Fall17.zip'
+    tempdir = tempfile.mkdtemp()
+    filepath = os.path.join(tempdir, 'perf_gtfs.zip')
+
+    response = urlopen(url_path)
+    zipcontent = response.read()
+    with open(filepath, 'wb') as f:
+        f.write(zipcontent)
+
+    feed = ptg.get_representative_feed(filepath)
+
+    start = 7 * 60 * 60  # 7:00 AM
+    end = 10 * 60 * 60  # 10:00 AM
+    G = pt.load_feed_as_graph(feed, start, end, interpolate_times=True)

--- a/performance/run_etl.py
+++ b/performance/run_etl.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 from urllib.request import urlopen
 
-import partridge as ptg
 import peartree as pt
 
 pt.utilities.config(log_console=True)
@@ -24,7 +23,7 @@ if __name__ == '__main__':
     with open(filepath, 'wb') as f:
         f.write(zipcontent)
 
-    feed = ptg.get_representative_feed(filepath)
+    feed = pt.get_representative_feed(filepath)
 
     start = 7 * 60 * 60  # 7:00 AM
     end = 10 * 60 * 60  # 10:00 AM


### PR DESCRIPTION
End visual:
![image](https://user-images.githubusercontent.com/6053396/38177630-3ce5eec0-35b9-11e8-953d-12a36e9cf257.png)

Using snakeviz since it is "good enough" and much simpler than dealing with `kcachegrind` set up in an OS project...