### PR TITLE
Use map operation on process pool

### DIFF
--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -337,9 +337,9 @@ def generate_edge_and_wait_values(
         cpu_count = mp.cpu_count()
         log('Running parallelized route costing on '
             '{} processes'.format(cpu_count))
-        pool = mp.Pool(processes=cpu_count)
-        results = pool.map(route_analyzer.generate_route_costs,
-                           feed.routes.route_id)
+        with mp.Pool(processes=cpu_count) as pool:
+            results = pool.map(route_analyzer.generate_route_costs,
+                               feed.routes.route_id)
     else:
         results = [route_analyzer.generate_route_costs(rid)
                    for rid in feed.routes.route_id]

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -336,15 +336,11 @@ def generate_edge_and_wait_values(
         log('Running parallelized route costing on '
             '{} processes'.format(cpu_count))
         pool = mp.Pool(processes=cpu_count)
-        route_ids = feed.routes.route_id
-        results = [
-            pool.apply_async(route_analyzer.generate_route_costs,
-                             args=[route_id, ]) for route_id in route_ids]
-        results = [process.get() for process in results]
+        results = pool.map(route_analyzer.generate_route_costs,
+                           feed.routes.route_id)
     else:
-        results = []
-        for rid in feed.routes.route_id:
-            results.append(route_analyzer.generate_route_costs(rid))
+        results = [route_analyzer.generate_route_costs(rid)
+                   for rid in feed.routes.route_id]
 
     all_edge_costs = None
     all_wait_times = None

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -1,4 +1,5 @@
 import multiprocessing as mp
+import time
 from typing import Dict, List, Tuple, Union
 
 import numpy as np
@@ -331,6 +332,7 @@ def generate_edge_and_wait_values(
         stop_times,
         feed.stops.copy())
 
+    start_time = time.time()
     if use_multiprocessing is True:
         cpu_count = mp.cpu_count()
         log('Running parallelized route costing on '
@@ -341,6 +343,8 @@ def generate_edge_and_wait_values(
     else:
         results = [route_analyzer.generate_route_costs(rid)
                    for rid in feed.routes.route_id]
+    elapsed = round(time.time() - start_time, 2)
+    log('Route costing complete. Execution time: {}s'.format(elapsed))
 
     all_edge_costs = None
     all_wait_times = None


### PR DESCRIPTION
`apply_async` was for a single process. If we don't care about order, I believe `map_async` is the way to go. Perhaps best to preserve order of route ids for now, as we have other sort-based operations downstream (not that any were impacted by previous async method).