### PR TITLE
[performance] Utilize mp.BaseManager to share reference object among processes

### DIFF
--- a/peartree/parallel.py
+++ b/peartree/parallel.py
@@ -1,0 +1,54 @@
+import random
+import numpy as np
+import time
+import multiprocessing
+from multiprocessing.managers import BaseManager
+
+LEN = 1000000 * 100 * 4
+OVERRIDE_CC = None
+
+def make_col(val):
+    return val * np.arange(LEN)
+
+class MyManager(BaseManager): pass
+
+def Manager():
+    m = MyManager()
+    m.start()
+    return m 
+
+class Counter(object):
+    def __init__(self):
+        self.ref_body = {
+            'a': make_col(1),
+            'b': make_col(2),
+            'c': make_col(3)}
+
+    def update(self, value):
+        rb = self.ref_body
+        
+        for key in rb.keys():
+            # perform some computation
+            rb[key].mean() * value
+
+MyManager.register('Counter', Counter)
+
+def update(counter_proxy, thread_id):
+    time.sleep(random.random() * 0.5)
+    counter_proxy.update(1)
+    print('on t_id %s' % thread_id)
+    return counter_proxy
+
+def main():
+    manager = Manager()
+    counter = manager.Counter()
+    cc = multiprocessing.cpu_count()
+
+    if OVERRIDE_CC:
+        cc = OVERRIDE_CC
+    print('cpus', cc)
+
+    pool = multiprocessing.Pool(cc)
+    pool.starmap(update, [(counter, i) for i in range(10)])
+
+    print('done')

--- a/peartree/parallel.py
+++ b/peartree/parallel.py
@@ -1,54 +1,209 @@
-import random
-import numpy as np
-import time
-import multiprocessing
 from multiprocessing.managers import BaseManager
+from typing import Dict, List, Union
 
-LEN = 1000000 * 100 * 4
-OVERRIDE_CC = None
+import numpy as np
+import pandas as pd
 
-def make_col(val):
-    return val * np.arange(LEN)
+from .utilities import log
 
-class MyManager(BaseManager): pass
 
-def Manager():
-    m = MyManager()
-    m.start()
-    return m 
+class RouteProcessorManager(BaseManager):
+    pass
 
-class Counter(object):
-    def __init__(self):
-        self.ref_body = {
-            'a': make_col(1),
-            'b': make_col(2),
-            'c': make_col(3)}
 
-    def update(self, value):
-        rb = self.ref_body
-        
-        for key in rb.keys():
-            # perform some computation
-            rb[key].mean() * value
+class RouteProcessor(object):
 
-MyManager.register('Counter', Counter)
+    def __init__(
+            self,
+            target_time_start: int,
+            target_time_end: int,
+            feed_trips: pd.DataFrame,
+            stop_times: pd.DataFrame,
+            all_stops: pd.DataFrame):
 
-def update(counter_proxy, thread_id):
-    time.sleep(random.random() * 0.5)
-    counter_proxy.update(1)
-    print('on t_id %s' % thread_id)
-    return counter_proxy
+        # Initialize common parameters
+        self.target_time_start = target_time_start
+        self.target_time_end = target_time_end
+        self.trips = feed_trips.copy()
+        self.stop_times = stop_times.copy()
 
-def main():
-    manager = Manager()
-    counter = manager.Counter()
-    cc = multiprocessing.cpu_count()
+        # Ensure that stop_ids are cast as string
+        astops = all_stops.copy()
+        astops['stop_id'] = astops['stop_id'].astype(str)
+        self.all_stops = astops
 
-    if OVERRIDE_CC:
-        cc = OVERRIDE_CC
-    print('cpus', cc)
+    def generate_route_costs(self, route_id: str):
+        # Get all the subset of trips that are related to this route
+        trips = self.trips.loc[route_id].copy()
 
-    pool = multiprocessing.Pool(cc)
-    pool.starmap(update, [(counter, i) for i in range(10)])
+        # Pandas will try and make returned result a Series if there
+        # is only one result - prevent this from happening
+        if isinstance(trips, pd.Series):
+            trips = trips.to_frame().T
 
-    print('done')
+        # Get just the stop times related to this trip
+        st_trip_id_mask = self.stop_times.trip_id.isin(trips.trip_id)
+        stimes_init = self.stop_times[st_trip_id_mask].copy()
+
+        # Then subset further by just the time period that we care about
+        start_time_mask = (stimes_init.arrival_time >= self.target_time_start)
+        end_time_mask = (stimes_init.arrival_time <= self.target_time_end)
+        stimes = stimes_init[start_time_mask & end_time_mask]
+
+        # Report on progress if requested
+        a = len(stimes_init.trip_id.unique())
+        b = len(stimes.trip_id.unique())
+        log('\tReduced selected trips on route {} from {} to {}.'.format(
+            route_id, a, b))
+
+        trips_and_stop_times = pd.merge(trips,
+                                        stimes,
+                                        how='inner',
+                                        on='trip_id')
+
+        trips_and_stop_times = pd.merge(trips_and_stop_times,
+                                        self.all_stops.copy(),
+                                        how='inner',
+                                        on='stop_id')
+
+        sort_list = ['stop_sequence',
+                     'arrival_time',
+                     'departure_time']
+        trips_and_stop_times = trips_and_stop_times.sort_values(sort_list)
+
+        wait_times = generate_wait_times(trips_and_stop_times)
+        trips_and_stop_times['wait_dir_0'] = wait_times[0]
+        trips_and_stop_times['wait_dir_1'] = wait_times[1]
+
+        tst_sub = trips_and_stop_times[['stop_id',
+                                        'wait_dir_0',
+                                        'wait_dir_1']]
+
+        # Get all edge costs for this route and add to the running total
+        edge_costs = generate_all_observed_edge_costs(trips_and_stop_times)
+
+        return (tst_sub, edge_costs)
+
+
+def calculate_average_wait(direction_times: pd.DataFrame) -> float:
+    # Exit early if we do not have enough values to calculate a mean
+    at = direction_times.arrival_time
+    if len(at) < 2:
+        return np.nan
+
+    first = at[1:].values
+    second = at[:-1].values
+    wait_seconds = (first - second)
+
+    # TODO: Can implement something more substantial here that takes into
+    #       account divergent/erratic performance or intentional timing
+    #       clusters that are not evenly dispersed
+    na = np.array(wait_seconds)
+    average_wait = na.mean()
+    return average_wait
+
+
+def generate_wait_times(trips_and_stop_times: pd.DataFrame
+                        ) -> Dict[int, List[float]]:
+    wait_times = {0: [], 1: []}
+    for stop_id in trips_and_stop_times.stop_id:
+
+        # Handle both inbound and outbound directions
+        for direction in [0, 1]:
+            # Check if direction_id exists in source data
+            if 'direction_id' in trips_and_stop_times:
+                constraint_1 = (trips_and_stop_times.direction_id == direction)
+                constraint_2 = (trips_and_stop_times.stop_id == stop_id)
+                both_constraints = (constraint_1 & constraint_2)
+                direction_subset = trips_and_stop_times[both_constraints]
+            else:
+                direction_subset = trips_and_stop_times.copy()
+
+            # Only run if each direction is contained
+            # in the same trip id
+            if direction_subset.empty:
+                average_wait = np.nan
+            else:
+                average_wait = calculate_average_wait(direction_subset)
+
+            # Add according to which direction we are working with
+            wait_times[direction].append(average_wait)
+
+    return wait_times
+
+
+def generate_all_observed_edge_costs(trips_and_stop_times: pd.DataFrame
+                                     ) -> Union[None, pd.DataFrame]:
+    # TODO: This edge case should be handled up stream. If there is
+    #       no direction id upstream, when the trip and stop times
+    #       dataframe is created, then it should be added there and all
+    #       directions should be set to default 0 or 1.
+    # Make sure that the GTFS feed has a direction id
+    has_dir_col = 'direction_id' in trips_and_stop_times.columns.values
+
+    all_edge_costs = []
+    all_from_stop_ids = []
+    all_to_stop_ids = []
+    for trip_id in trips_and_stop_times.trip_id.unique():
+        tst_mask = (trips_and_stop_times.trip_id == trip_id)
+        tst_sub = trips_and_stop_times[tst_mask]
+
+        # Just in case both directions are under the same trip id
+        for direction in [0, 1]:
+            # Support situations wheredirection_id is absent from the
+            # GTFS data. In such situations, include all trip and stop
+            # time data, instead of trying to split on that column
+            # (since it would not exist).
+            if has_dir_col:
+                dir_mask = (tst_sub.direction_id == direction)
+                tst_sub_dir = tst_sub[dir_mask]
+            else:
+                tst_sub_dir = tst_sub
+
+            tst_sub_dir = tst_sub_dir.sort_values('stop_sequence')
+            deps = tst_sub_dir.departure_time[:-1]
+            arrs = tst_sub_dir.arrival_time[1:]
+
+            # Use .values to strip existing indices
+            edge_costs = np.subtract(arrs.values, deps.values)
+
+            # TODO(kuanb): Negative values can result here!
+            # HACK: There are times when the arrival and departure data
+            #       are "out of order" which results in negative values.
+            #       From the values I've looked at, these are edge cases
+            #       that have to do with start/end overlaps. I don't have
+            #       a good answer for dealing with these but, since they
+            #       are possible noise, they can be override by taking
+            #       their absolute value.
+            edge_costs = np.absolute(edge_costs)
+
+            # Add each resulting list to the running array totals
+            all_edge_costs += list(edge_costs)
+
+            fr_ids = tst_sub_dir.stop_id[:-1].values
+            all_from_stop_ids += list(fr_ids)
+
+            to_ids = tst_sub_dir.stop_id[1:].values
+            all_to_stop_ids += list(to_ids)
+
+    # Only return a dataframe if there is contents to populate
+    # it with
+    if len(all_edge_costs) > 0:
+        # Now place results in data frame
+        return pd.DataFrame({
+            'edge_cost': all_edge_costs,
+            'from_stop_id': all_from_stop_ids,
+            'to_stop_id': all_to_stop_ids})
+
+    # Otherwise a None value should be returned
+    else:
+        return None
+
+
+def make_new_route_processor_manager():
+    manager = RouteProcessorManager()
+    manager.start()
+    return manager
+
+
+RouteProcessorManager.register('RouteProcessor', RouteProcessor)

--- a/peartree/paths.py
+++ b/peartree/paths.py
@@ -58,7 +58,7 @@ def load_feed_as_graph(feed: ptg.gtfs.feed,
                        walk_speed_kmph: float=4.5,
                        interpolate_times: bool=True,
                        impute_walk_transfers: bool=False,
-                       use_multiprocessing: bool=True):
+                       use_multiprocessing: bool=False):
     """
     Convert a feed object into a NetworkX Graph, connect to an existing
     NetworkX graph if one is supplied

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -1,11 +1,13 @@
 import multiprocessing as mp
 import time
-from typing import Dict, List, Tuple, Union
+from typing import Tuple
 
 import numpy as np
 import pandas as pd
 import partridge as ptg
 
+from .parallel import (RouteProcessor, RouteProcessorManager,
+                       make_new_route_processor_manager)
 from .toolkit import nan_helper
 from .utilities import log
 
@@ -26,103 +28,6 @@ def calculate_average_wait(direction_times: pd.DataFrame) -> float:
     na = np.array(wait_seconds)
     average_wait = na.mean()
     return average_wait
-
-
-def generate_wait_times(trips_and_stop_times: pd.DataFrame
-                        ) -> Dict[int, List[float]]:
-    wait_times = {0: [], 1: []}
-    for stop_id in trips_and_stop_times.stop_id:
-
-        # Handle both inbound and outbound directions
-        for direction in [0, 1]:
-            # Check if direction_id exists in source data
-            if 'direction_id' in trips_and_stop_times:
-                constraint_1 = (trips_and_stop_times.direction_id == direction)
-                constraint_2 = (trips_and_stop_times.stop_id == stop_id)
-                both_constraints = (constraint_1 & constraint_2)
-                direction_subset = trips_and_stop_times[both_constraints]
-            else:
-                direction_subset = trips_and_stop_times.copy()
-
-            # Only run if each direction is contained
-            # in the same trip id
-            if direction_subset.empty:
-                average_wait = np.nan
-            else:
-                average_wait = calculate_average_wait(direction_subset)
-
-            # Add according to which direction we are working with
-            wait_times[direction].append(average_wait)
-
-    return wait_times
-
-
-def generate_all_observed_edge_costs(trips_and_stop_times: pd.DataFrame
-                                     ) -> Union[None, pd.DataFrame]:
-    # TODO: This edge case should be handled up stream. If there is
-    #       no direction id upstream, when the trip and stop times
-    #       dataframe is created, then it should be added there and all
-    #       directions should be set to default 0 or 1.
-    # Make sure that the GTFS feed has a direction id
-    has_dir_col = 'direction_id' in trips_and_stop_times.columns.values
-
-    all_edge_costs = []
-    all_from_stop_ids = []
-    all_to_stop_ids = []
-    for trip_id in trips_and_stop_times.trip_id.unique():
-        tst_mask = (trips_and_stop_times.trip_id == trip_id)
-        tst_sub = trips_and_stop_times[tst_mask]
-
-        # Just in case both directions are under the same trip id
-        for direction in [0, 1]:
-            # Support situations wheredirection_id is absent from the
-            # GTFS data. In such situations, include all trip and stop
-            # time data, instead of trying to split on that column
-            # (since it would not exist).
-            if has_dir_col:
-                dir_mask = (tst_sub.direction_id == direction)
-                tst_sub_dir = tst_sub[dir_mask]
-            else:
-                tst_sub_dir = tst_sub
-
-            tst_sub_dir = tst_sub_dir.sort_values('stop_sequence')
-            deps = tst_sub_dir.departure_time[:-1]
-            arrs = tst_sub_dir.arrival_time[1:]
-
-            # Use .values to strip existing indices
-            edge_costs = np.subtract(arrs.values, deps.values)
-
-            # TODO(kuanb): Negative values can result here!
-            # HACK: There are times when the arrival and departure data
-            #       are "out of order" which results in negative values.
-            #       From the values I've looked at, these are edge cases
-            #       that have to do with start/end overlaps. I don't have
-            #       a good answer for dealing with these but, since they
-            #       are possible noise, they can be override by taking
-            #       their absolute value.
-            edge_costs = np.absolute(edge_costs)
-
-            # Add each resulting list to the running array totals
-            all_edge_costs += list(edge_costs)
-
-            fr_ids = tst_sub_dir.stop_id[:-1].values
-            all_from_stop_ids += list(fr_ids)
-
-            to_ids = tst_sub_dir.stop_id[1:].values
-            all_to_stop_ids += list(to_ids)
-
-    # Only return a dataframe if there is contents to populate
-    # it with
-    if len(all_edge_costs) > 0:
-        # Now place results in data frame
-        return pd.DataFrame({
-            'edge_cost': all_edge_costs,
-            'from_stop_id': all_from_stop_ids,
-            'to_stop_id': all_to_stop_ids})
-
-    # Otherwise a None value should be returned
-    else:
-        return None
 
 
 def summarize_edge_costs(df: pd.DataFrame) -> pd.DataFrame:
@@ -305,6 +210,12 @@ def linearly_interpolate_infill_times(stops_orig_df):
     return cleaned
 
 
+def _route_analyzer_pool_map(
+        route_analyzer_proxy: RouteProcessor,
+        target_route_id: str):
+    return route_analyzer_proxy.generate_route_costs(target_route_id)
+
+
 def generate_edge_and_wait_values(
         feed: ptg.gtfs.feed,
         target_time_start: int,
@@ -325,24 +236,34 @@ def generate_edge_and_wait_values(
     else:
         stop_times = feed.stop_times.copy()
 
-    route_analyzer = RouteProcessor(
-        target_time_start,
-        target_time_end,
-        ftrips,
-        stop_times,
-        feed.stops.copy())
-
     start_time = time.time()
+    target_route_ids = feed.routes.route_id.head(20)
     if use_multiprocessing is True:
         cpu_count = mp.cpu_count()
         log('Running parallelized route costing on '
             '{} processes'.format(cpu_count))
+
+        manager = make_new_route_processor_manager(RouteProcessor)
+        route_analyzer = manager.RouteProcessor(
+            target_time_start,
+            target_time_end,
+            ftrips,
+            stop_times,
+            feed.stops.copy())
+
         with mp.Pool(processes=cpu_count) as pool:
-            results = pool.map(route_analyzer.generate_route_costs,
-                               feed.routes.route_id)
+            pool.starmap(_route_analyzer_pool_map,
+                         [(route_analyzer,
+                           route_id) for route_id in target_route_ids])
     else:
+        route_analyzer = RouteProcessor(
+            target_time_start,
+            target_time_end,
+            ftrips,
+            stop_times,
+            feed.stops.copy())
         results = [route_analyzer.generate_route_costs(rid)
-                   for rid in feed.routes.route_id]
+                   for rid in target_route_ids]
     elapsed = round(time.time() - start_time, 2)
     log('Route costing complete. Execution time: {}s'.format(elapsed))
 
@@ -362,77 +283,3 @@ def generate_edge_and_wait_values(
             all_edge_costs = all_edge_costs.append(edge_costs)
 
     return (all_edge_costs, all_wait_times)
-
-
-class RouteProcessor(object):
-
-    def __init__(
-            self,
-            target_time_start: int,
-            target_time_end: int,
-            feed_trips: pd.DataFrame,
-            stop_times: pd.DataFrame,
-            all_stops: pd.DataFrame):
-
-        # Initialize common parameters
-        self.target_time_start = target_time_start
-        self.target_time_end = target_time_end
-        self.trips = feed_trips.copy()
-        self.stop_times = stop_times.copy()
-
-        # Ensure that stop_ids are cast as string
-        astops = all_stops.copy()
-        astops['stop_id'] = astops['stop_id'].astype(str)
-        self.all_stops = astops
-
-    def generate_route_costs(self, route_id: str):
-        # Get all the subset of trips that are related to this route
-        trips = self.trips.loc[route_id].copy()
-
-        # Pandas will try and make returned result a Series if there
-        # is only one result - prevent this from happening
-        if isinstance(trips, pd.Series):
-            trips = trips.to_frame().T
-
-        # Get just the stop times related to this trip
-        st_trip_id_mask = self.stop_times.trip_id.isin(trips.trip_id)
-        stimes_init = self.stop_times[st_trip_id_mask].copy()
-
-        # Then subset further by just the time period that we care about
-        start_time_mask = (stimes_init.arrival_time >= self.target_time_start)
-        end_time_mask = (stimes_init.arrival_time <= self.target_time_end)
-        stimes = stimes_init[start_time_mask & end_time_mask]
-
-        # Report on progress if requested
-        a = len(stimes_init.trip_id.unique())
-        b = len(stimes.trip_id.unique())
-        log('\tReduced selected trips on route {} from {} to {}.'.format(
-            route_id, a, b))
-
-        trips_and_stop_times = pd.merge(trips,
-                                        stimes,
-                                        how='inner',
-                                        on='trip_id')
-
-        trips_and_stop_times = pd.merge(trips_and_stop_times,
-                                        self.all_stops.copy(),
-                                        how='inner',
-                                        on='stop_id')
-
-        sort_list = ['stop_sequence',
-                     'arrival_time',
-                     'departure_time']
-        trips_and_stop_times = trips_and_stop_times.sort_values(sort_list)
-
-        wait_times = generate_wait_times(trips_and_stop_times)
-        trips_and_stop_times['wait_dir_0'] = wait_times[0]
-        trips_and_stop_times['wait_dir_1'] = wait_times[1]
-
-        tst_sub = trips_and_stop_times[['stop_id',
-                                        'wait_dir_0',
-                                        'wait_dir_1']]
-
-        # Get all edge costs for this route and add to the running total
-        edge_costs = generate_all_observed_edge_costs(trips_and_stop_times)
-
-        return (tst_sub, edge_costs)

--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -212,7 +212,7 @@ def coalesce(G: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
     # Next we group by the edge pattern (from -> to)
     grouped = edges_df.groupby(['fr', 'to'], sort=False)
     # With the resulting groupings, we extract values
-    min_edges = grouped['weight'].min()
+    min_edges = grouped['len'].min()
 
     # Second step; which uses results from edge_df grouping/parsing
     edges_to_add = []
@@ -234,8 +234,9 @@ def coalesce(G: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
             existing_edge = G[rn1][rn2]
             # Also sanity check that it is the min length value
             if not existing_edge['length'] == min_length:
-                raise ValueError('Edge should have had minimum length of '
-                                 '{}, but instead had value of {}'.format(min_length))
+                raise ValueError(
+                    'Edge should have had minimum length of '
+                    '{}, but instead had value of {}'.format(min_length))
 
         # If this happens, then this is the first time this edge
         # is being added

--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -196,13 +196,20 @@ def coalesce(G: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
         new_node_coords[nni]['boarding_cost'] = avg_bc
 
     # First step to creating a list of replacement edges
-    edge_df_mtx = []
+    replacement_edges_fr = []
+    replacement_edges_to = []
+    replacement_edges_len = []
     for n1, n2, edge in G.edges(data=True):
         # This will be used to parse out which edges to keep
-        edge_df_mtx.append([reference[n1], reference[n2], edge['length']])
+        replacement_edges_fr.append(reference[n1])
+        replacement_edges_to.append(reference[n2])
+        replacement_edges_len.append(edge['length'])
     
     # This takes the resulting matrix and converts it to a pandas DataFrame
-    edges_df = pd.DataFrame(edge_df_mtx, columns=['fr', 'to', 'weight'])
+    edges_df = pd.DataFrame({
+        'fr': replacement_edges_fr,
+        'to': replacement_edges_to,
+        'len': replacement_edges_len})
     # Next we group by the edge pattern (from -> to)
     grouped = edges_df.groupby(['fr', 'to'], sort=False)
     # With the resulting groupings, we extract values 

--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -172,7 +172,6 @@ def coalesce(G: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
     new_node_coords = {}
     lookup = {}
 
-
     # Populate the fresh reference dictionaries
     for x in grouped:
         for y in grouped[x]:
@@ -204,7 +203,7 @@ def coalesce(G: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
         replacement_edges_fr.append(reference[n1])
         replacement_edges_to.append(reference[n2])
         replacement_edges_len.append(edge['length'])
-    
+
     # This takes the resulting matrix and converts it to a pandas DataFrame
     edges_df = pd.DataFrame({
         'fr': replacement_edges_fr,
@@ -212,9 +211,9 @@ def coalesce(G: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
         'len': replacement_edges_len})
     # Next we group by the edge pattern (from -> to)
     grouped = edges_df.groupby(['fr', 'to'], sort=False)
-    # With the resulting groupings, we extract values 
+    # With the resulting groupings, we extract values
     min_edges = grouped['weight'].min()
-    
+
     # Second step; which uses results from edge_df grouping/parsing
     edges_to_add = []
     for n1, n2, edge in G.edges(data=True):
@@ -236,7 +235,7 @@ def coalesce(G: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
             # Also sanity check that it is the min length value
             if not existing_edge['length'] == min_length:
                 raise ValueError('Edge should have had minimum length of '
-                    '{}, but instead had value of {}'.format(min_length))
+                                 '{}, but instead had value of {}'.format(min_length))
 
         # If this happens, then this is the first time this edge
         # is being added

--- a/performance/run_etl.py
+++ b/performance/run_etl.py
@@ -22,9 +22,10 @@ if __name__ == '__main__':
     zipcontent = response.read()
     with open(filepath, 'wb') as f:
         f.write(zipcontent)
-
     feed = pt.get_representative_feed(filepath)
 
     start = 7 * 60 * 60  # 7:00 AM
     end = 10 * 60 * 60  # 10:00 AM
-    G = pt.load_feed_as_graph(feed, start, end, interpolate_times=True)
+    G = pt.load_feed_as_graph(feed, start, end,
+                              interpolate_times=True,
+                              use_multiprocessing=False)

--- a/tests/test_graph_assembly.py
+++ b/tests/test_graph_assembly.py
@@ -18,7 +18,7 @@ def test_feed_to_graph_performance():
     start = 7 * 60 * 60
     end = 10 * 60 * 60
     interpolate_times = True
-    use_multiprocessing = True
+    use_multiprocessing = False
 
     print('Running time profiles on each major '
           'function in graph generation workflow')


### PR DESCRIPTION
Fixes https://github.com/kuanb/peartree/issues/59

Work towards dealing with https://github.com/kuanb/peartree/issues/12

Utilizes the `BaseManager` class to enable the `multiprocessing` `starmap` operation's mapped function to access a shared object containing read-only reference data needed by the function being run in parallel.

![kapture 2018-04-10 at 21 44 57](https://user-images.githubusercontent.com/6053396/38597133-9dfa50d6-3d0a-11e8-8b9a-f890521c9869.gif)
Short GIF capturing `htop` output while peartree is run on a sample GTFS feed in a docker container with access to 2 CPUs. 

Performance of `run_etl.py` profiler script (runs graph extraction on AC Transit feed) on 2016 MBP:
```
Parallelized, using 4 CPUs: 39s
Serial (no parallelization): 50s
```

H/T to @bryanculbertson for pointing me in the right direction with this.