### PR TITLE
Custom implementation of simplify_graph

### DIFF
--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -289,19 +289,15 @@ def _path_has_consistent_mode_type(G, path):
 
 
 def simplify_graph(G_orig: nx.MultiDiGraph) -> nx.MultiDiGraph:
-    # Note: This operation borrows heavily from the operation of 
+    # Note: This operation borrows heavily from the operation of
     #       the same name in OSMnx, as it existed in this state/commit:
     #       github.com/gboeing/osmnx/blob/
     #       c5916aab5c9b94c951c8fb1964c841899c9467f8/osmnx/simplify.py
     #       Function on line 203
-    
+
     # Prevent upstream mutation, always copy
     G = G_orig.copy()
-    
-    # Take some statistics for logging changes later
-    initial_node_count = len(list(G.nodes()))
-    initial_edge_count = len(list(G.edges()))
-    
+
     # Used to track updates to execute
     all_nodes_to_remove = []
     all_edges_to_add = []
@@ -318,11 +314,11 @@ def simplify_graph(G_orig: nx.MultiDiGraph) -> nx.MultiDiGraph:
         # proposed simplification
         if not _path_has_consistent_mode_type(G, path):
             continue
-        
+
         # Keep track of the edges to be removed so we can
         # assemble a LineString geometry with all of them
         edge_attributes = {}
-        
+
         # Work from the last edge through, "wrapped around," to the beginning
         for u, v in zip(path[:-1], path[1:]):
             # Should not be multiple edges between interstitial nodes
@@ -356,8 +352,8 @@ def simplify_graph(G_orig: nx.MultiDiGraph) -> nx.MultiDiGraph:
 
         # Add nodes and edges to respective lists for processing
         all_nodes_to_remove.extend(path[1:-1])
-        all_edges_to_add.append({'origin':path[0],
-                                 'destination':path[-1],
+        all_edges_to_add.append({'origin': path[0],
+                                 'destination': path[-1],
                                  'attr_dict': edge_attributes})
 
     # For each edge to add in the list we assembled, create a new edge between
@@ -368,10 +364,4 @@ def simplify_graph(G_orig: nx.MultiDiGraph) -> nx.MultiDiGraph:
     # Remove all the interstitial nodes between the new edges, which will also
     # knock out the related edges from the graph
     G.remove_nodes_from(set(all_nodes_to_remove))
-
-    log(('Simplified graph (from {:,} to {:,} nodes and from {:,} to {:,} '
-         'edges)').format(initial_node_count,
-                          len(list(G.nodes())),
-                          initial_edge_count,
-                          len(list(G.edges()))))
     return G

--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -306,10 +306,10 @@ def simplify_graph(G_orig: nx.MultiDiGraph) -> nx.MultiDiGraph:
     #       removal proposals
     # Utilize the recursive function from OSMnx that identifies paths based
     # on isolated successor nodes
-    paths = ox.simplify.get_paths_to_simplify(G)
+    paths_to_consider = ox.simplify.get_paths_to_simplify(G)
 
     # Iterate through the resulting path arrays to target
-    for path in paths:
+    for path in paths_to_consider:
         # If the path is not all one mode of travel, skip the
         # proposed simplification
         if not _path_has_consistent_mode_type(G, path):

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -1,6 +1,12 @@
 import networkx as nx
 import pytest
-from peartree.toolkit import coalesce, reproject
+
+from peartree.paths import get_representative_feed
+from peartree.toolkit import coalesce, reproject, simplify_graph
+
+
+def fixture(filename):
+    return os.path.join(os.path.dirname(__file__), 'fixtures', filename)
 
 
 def _dict_equal(got, want):
@@ -87,3 +93,25 @@ def test_coalesce_operation():
 
     # Make sure that the one edge came out as expected
     assert _dict_equal(all_edges[0][2], {'length': 10, 'mode': 'transit'})
+
+
+def test_simplify_graph():
+    path = fixture('samtrans-2017-11-28.zip')
+    feed = get_representative_feed(path)
+
+    start = 7 * 60 * 60
+    end = 10 * 60 * 60
+    G = load_feed_as_graph(feed, start, end)
+
+    # Run simplification
+    Gs = simplify_graph(G)
+
+    assert len(Gs2.nodes()) == 347
+    assert len(Gs2.edges()) == 559
+
+    (e30_fr, e30_to, edge_30) = list(Gs2.edges(data=True))[30]
+    assert edge_30['length'] == 120.0
+    assert edge_30['mode'] == 'transit'
+
+    # And make sure the geometry is compose of the same node count
+    assert len(edge_30['geometry'].coords.xy[0]) == 4

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -100,20 +100,16 @@ def test_simplify_graph():
     path = fixture('samtrans-2017-11-28.zip')
     feed = get_representative_feed(path)
 
+    # Shorter amount of time to speed up the test
     start = 7 * 60 * 60
-    end = 10 * 60 * 60
+    end = 8 * 60 * 60
     G = load_feed_as_graph(feed, start, end)
 
     # Run simplification
     Gs = simplify_graph(G)
 
-    assert len(Gs.nodes()) == 347
-    assert len(Gs.edges()) == 559
-
-    (e30_fr, e30_to, edge_30) = list(Gs.edges(data=True))[30]
-    assert edge_30['length'] == 120.0
-    assert edge_30['mode'] == 'transit'
-
-    # And make sure the geometry is compose of the same node count
-    print(edge_30)
-    assert len(edge_30['geometry'].coords.xy[0]) == 4
+    # TODO: We have this ongoing issue where we can't
+    #       consistently test by index for edges, so we need
+    #       to figure out _how_ to test for a specific edge
+    assert len(Gs.nodes()) == 298
+    assert len(Gs.edges()) == 466

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -115,4 +115,5 @@ def test_simplify_graph():
     assert edge_30['mode'] == 'transit'
 
     # And make sure the geometry is compose of the same node count
+    print(edge_30)
     assert len(edge_30['geometry'].coords.xy[0]) == 4

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -1,7 +1,8 @@
+import os
+
 import networkx as nx
 import pytest
-
-from peartree.paths import get_representative_feed
+from peartree.paths import get_representative_feed, load_feed_as_graph
 from peartree.toolkit import coalesce, reproject, simplify_graph
 
 
@@ -106,10 +107,10 @@ def test_simplify_graph():
     # Run simplification
     Gs = simplify_graph(G)
 
-    assert len(Gs2.nodes()) == 347
-    assert len(Gs2.edges()) == 559
+    assert len(Gs.nodes()) == 347
+    assert len(Gs.edges()) == 559
 
-    (e30_fr, e30_to, edge_30) = list(Gs2.edges(data=True))[30]
+    (e30_fr, e30_to, edge_30) = list(Gs.edges(data=True))[30]
     assert edge_30['length'] == 120.0
     assert edge_30['mode'] == 'transit'
 


### PR DESCRIPTION
Very much akin to the method of the same name in OSMnx (and have made sure to cite the function in the comments of the method). Has some updates that help with using the method with peartree, names:

- no list assembly of other misc. attributes
- checks to ensure that we don't simplify walk and transit mode segments

Note: Also relevant as a "good enough" replacement for the desired feature add in Issue https://github.com/kuanb/peartree/issues/46