### PR TITLE
Fix dropped edges during a coalesce operation

### DIFF
--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -149,13 +149,13 @@ def reproject(G: nx.MultiDiGraph, to_epsg: int=2163) -> nx.MultiDiGraph:
     return G
 
 
-def coalesce(G: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
+def coalesce(G_orig: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
     # Make sure our resolution satisfies basic requirement
     if resolution < 1:
         raise ValueError('Resolution parameters must be >= 1')
 
     # Avoid upstream mutation of the graph
-    G = G.copy()
+    G = G_orig.copy()
 
     # Before we continue, attempt to simplfy the current network
     # such that we won't generate isolated nodes that become disconnected

--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -157,6 +157,11 @@ def coalesce(G: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
     # Avoid upstream mutation of the graph
     G = G.copy()
 
+    # Before we continue, attempt to simplfy the current network
+    # such that we won't generate isolated nodes that become disconnected
+    # from key coalesced nodes (because too many intermediary nodes)
+    G = simplify_graph(G)
+
     # Extract all x, y values
     grouped = {}
     for i, node in G.nodes(data=True):
@@ -219,7 +224,7 @@ def coalesce(G: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
     replacement_edges_fr = []
     replacement_edges_to = []
     replacement_edges_len = []
-    
+
     for n1, n2, edge in G.edges(data=True):
         # This will be used to parse out which edges to keep
         replacement_edges_fr.append(reference[n1])

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -54,7 +54,7 @@ def test_feed_to_graph_plot():
 
 def test_coalesce_operation():
     # Create a simple graph
-    G = nx.Graph(crs={'init': 'epsg:4326', 'no_defs': True}, name='foo')
+    G = nx.MultiDiGraph(crs={'init': 'epsg:4326', 'no_defs': True}, name='foo')
 
     # And add two nodes to it
     G.add_node('a', x=-122.2729918, y=37.7688136, boarding_cost=10)

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -88,7 +88,7 @@ def test_coalesce_operation():
         assert (a or b)
 
     all_edges = list(G2c.edges(data=True))
-    assert len(all_edges) == 1
+    assert len(all_edges) == 2
 
     # Make sure that the one edge came out as expected
     assert _dict_equal(all_edges[0][2], {'length': 10, 'mode': 'transit'})

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -78,7 +78,6 @@ def test_coalesce_operation():
     G2 = reproject(G)
 
     G2c = coalesce(G2, 200)
-    G2c.nodes(data=True), G2c.edges(data=True)
 
     # Same akward situation as before, where edges are returned in
     # different order between Py 3.5 and 3.6

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -76,7 +76,6 @@ def test_coalesce_operation():
     G.add_edge('a', 'b_alt', length=10, mode='transit')
 
     G2 = reproject(G)
-
     G2c = coalesce(G2, 200)
 
     # Same akward situation as before, where edges are returned in


### PR DESCRIPTION
Fixes https://github.com/kuanb/peartree/issues/57

Conveniently leverages the new simplify operation added to resolve lost edges and hanging nodes issue.

Example of LA (which was not working before) working now:
![image](https://user-images.githubusercontent.com/6053396/39088597-c5e7daa2-4569-11e8-9f03-451b4ae98f57.png)
