### PR TITLE
Thread through default fallback node/stop cost param

### DIFF
--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -34,9 +34,9 @@ def nameify_stop_id(name, sid):
 def generate_summary_graph_elements(feed: ptg.gtfs.feed,
                                     target_time_start: int,
                                     target_time_end: int,
+                                    fallback_stop_cost: float,
                                     interpolate_times: bool,
-                                    use_multiprocessing: bool,
-                                    fallback_stop_cost: float):
+                                    use_multiprocessing: bool):
     (all_edge_costs,
      all_wait_times) = generate_edge_and_wait_values(feed,
                                                      target_time_start,

--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -35,7 +35,8 @@ def generate_summary_graph_elements(feed: ptg.gtfs.feed,
                                     target_time_start: int,
                                     target_time_end: int,
                                     interpolate_times: bool,
-                                    use_multiprocessing: bool):
+                                    use_multiprocessing: bool,
+                                    fallback_stop_cost: float):
     (all_edge_costs,
      all_wait_times) = generate_edge_and_wait_values(feed,
                                                      target_time_start,
@@ -52,7 +53,8 @@ def generate_summary_graph_elements(feed: ptg.gtfs.feed,
                                          'valid wait times from feed object.')
 
     summary_edge_costs = generate_summary_edge_costs(all_edge_costs)
-    wait_times_by_stop = generate_summary_wait_times(all_wait_times)
+    wait_times_by_stop = generate_summary_wait_times(all_wait_times,
+                                                     fallback_stop_cost)
 
     return (summary_edge_costs, wait_times_by_stop)
 

--- a/peartree/paths.py
+++ b/peartree/paths.py
@@ -8,6 +8,8 @@ from .graph import (generate_empty_md_graph, generate_summary_graph_elements,
 from .toolkit import generate_random_name
 from .utilities import log
 
+FALLBACK_STOP_COST_DEFAULT = (30 * 60)  # 30 minutes, converted to seconds
+
 
 class InvalidGTFS(Exception):
     # Let's have a custom exception for when we read in GTFS files
@@ -58,7 +60,8 @@ def load_feed_as_graph(feed: ptg.gtfs.feed,
                        walk_speed_kmph: float=4.5,
                        interpolate_times: bool=True,
                        impute_walk_transfers: bool=False,
-                       use_multiprocessing: bool=False):
+                       use_multiprocessing: bool=False,
+                       fallback_stop_cost: bool=FALLBACK_STOP_COST_DEFAULT):
     """
     Convert a feed object into a NetworkX Graph, connect to an existing
     NetworkX graph if one is supplied
@@ -125,7 +128,8 @@ def load_feed_as_graph(feed: ptg.gtfs.feed,
                                                            start_time,
                                                            end_time,
                                                            interpolate_times,
-                                                           use_multiprocessing)
+                                                           use_multiprocessing,
+                                                           fallback_stop_cost)
 
     # This is a flag used to check if we need to run any additional steps
     # after the feed is returned to ensure that new nodes and edge can connect

--- a/peartree/paths.py
+++ b/peartree/paths.py
@@ -58,10 +58,10 @@ def load_feed_as_graph(feed: ptg.gtfs.feed,
                        existing_graph: nx.MultiDiGraph=None,
                        connection_threshold: float=50.0,
                        walk_speed_kmph: float=4.5,
+                       fallback_stop_cost: bool=FALLBACK_STOP_COST_DEFAULT,
                        interpolate_times: bool=True,
                        impute_walk_transfers: bool=False,
-                       use_multiprocessing: bool=False,
-                       fallback_stop_cost: bool=FALLBACK_STOP_COST_DEFAULT):
+                       use_multiprocessing: bool=False):
     """
     Convert a feed object into a NetworkX Graph, connect to an existing
     NetworkX graph if one is supplied
@@ -93,6 +93,11 @@ def load_feed_as_graph(feed: ptg.gtfs.feed,
     walk_speed_kmph : float
         Walk speed in km/h, that is used to determine the cost in time when
         walking between two nodes that get an internal connection created
+    fallback_stop_cost: bool
+        Cost in seconds to board a line at a stop if no other data is able
+        to be calculated from schedule data for that stop to determine
+        what wait time is. Example of this situation would be when
+        there is only one scheduled stop time found for the stop id.
     interpolate_times : bool
         A boolean flag to indicate whether or not to infill intermediary stops
         that do not have all intermediary stop arrival times specified in the
@@ -127,9 +132,9 @@ def load_feed_as_graph(feed: ptg.gtfs.feed,
      wait_times_by_stop) = generate_summary_graph_elements(feed,
                                                            start_time,
                                                            end_time,
+                                                           fallback_stop_cost,
                                                            interpolate_times,
-                                                           use_multiprocessing,
-                                                           fallback_stop_cost)
+                                                           use_multiprocessing)
 
     # This is a flag used to check if we need to run any additional steps
     # after the feed is returned to ensure that new nodes and edge can connect

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -148,8 +148,8 @@ def generate_summary_wait_times(df: pd.DataFrame) -> pd.DataFrame:
         a = set(list(init_of_stop_ids))
         b = set(list(end_of_stop_ids))
         unresolved_ids = list(a - b)
-        log('Some unaccounted for stop '
-            'ids. Resolving {}...'.format(len(unresolved_ids)))
+        log('Some unaccounted for stop ids. '
+            'Resolving {}...'.format(len(unresolved_ids)))
 
         # TODO: Perhaps these are start/end stops and should adopt
         #       a cost that is "average" for that route?

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -70,7 +70,9 @@ def summarize_waits_at_one_stop(stop_df: pd.DataFrame) -> float:
     return calculated
 
 
-def generate_summary_wait_times(df: pd.DataFrame) -> pd.DataFrame:
+def generate_summary_wait_times(
+        df: pd.DataFrame,
+        fallback_stop_cost: float) -> pd.DataFrame:
     df_sub = df[['stop_id',
                  'wait_dir_0',
                  'wait_dir_1']].reset_index(drop=True)
@@ -161,7 +163,7 @@ def generate_summary_wait_times(df: pd.DataFrame) -> pd.DataFrame:
         acst = list(summed_reset.avg_cost)
         for i in unresolved_ids:
             sids.append(i)
-            acst.append(30 * 60)  # 30 minutes, converted to seconds
+            acst.append(fallback_stop_cost)
 
         # Rebuild the dataframe
         summed_reset = pd.DataFrame({'stop_id': sids, 'avg_cost': acst})

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,7 +2,7 @@ import os
 
 from peartree.graph import (generate_empty_md_graph,
                             generate_summary_graph_elements)
-from peartree.paths import get_representative_feed
+from peartree.paths import FALLBACK_STOP_COST_DEFAULT, get_representative_feed
 
 
 def fixture(filename):
@@ -22,7 +22,6 @@ def test_generate_summary_graph_elements():
     start = 7 * 60 * 60
     end = 10 * 60 * 60
     interpolate_times = True
-    fallback_stop_cost = 30 * 60
 
     # Make sure everything works the same with both multiprocessing on/off
     for use_multiprocessing in [True, False]:
@@ -31,7 +30,7 @@ def test_generate_summary_graph_elements():
             feed_1,
             start,
             end,
-            fallback_stop_cost,
+            FALLBACK_STOP_COST_DEFAULT,
             interpolate_times,
             use_multiprocessing)
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -22,6 +22,7 @@ def test_generate_summary_graph_elements():
     start = 7 * 60 * 60
     end = 10 * 60 * 60
     interpolate_times = True
+    fallback_stop_cost = 30 * 60
 
     # Make sure everything works the same with both multiprocessing on/off
     for use_multiprocessing in [True, False]:
@@ -31,7 +32,8 @@ def test_generate_summary_graph_elements():
             start,
             end,
             interpolate_times,
-            use_multiprocessing)
+            use_multiprocessing,
+            fallback_stop_cost)
 
         # Ensure that the summary edge cost dataframe looks as it should
         ec_cols = ['edge_cost', 'from_stop_id', 'to_stop_id']

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -31,9 +31,9 @@ def test_generate_summary_graph_elements():
             feed_1,
             start,
             end,
+            fallback_stop_cost,
             interpolate_times,
-            use_multiprocessing,
-            fallback_stop_cost)
+            use_multiprocessing)
 
         # Ensure that the summary edge cost dataframe looks as it should
         ec_cols = ['edge_cost', 'from_stop_id', 'to_stop_id']

--- a/tests/test_graph_assembly.py
+++ b/tests/test_graph_assembly.py
@@ -2,7 +2,7 @@ import os
 from time import time
 
 from peartree.graph import generate_empty_md_graph, populate_graph
-from peartree.paths import get_representative_feed
+from peartree.paths import FALLBACK_STOP_COST_DEFAULT, get_representative_feed
 from peartree.summarizer import (generate_edge_and_wait_values,
                                  generate_summary_edge_costs,
                                  generate_summary_wait_times)
@@ -48,7 +48,8 @@ def test_feed_to_graph_performance():
     print('Perf of generate_summary_edge_costs: {}s'.format(elapsed))
 
     a = time()
-    wait_times_by_stop = generate_summary_wait_times(all_wait_times)
+    wait_times_by_stop = generate_summary_wait_times(
+        all_wait_times, FALLBACK_STOP_COST_DEFAULT)
     elapsed = round(time() - a, 2)
     print('Perf of generate_summary_wait_times: {}s'.format(elapsed))
 


### PR DESCRIPTION
Used to be hardcoded in the `generate_summary_wait_times` method, now make it a kwarg.