### PR TITLE
Allow root for notebook container for more clear access address

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build:
       context: .
     env_file: .env
-    command: jupyter notebook --config jupyter_notebook_config.py
+    command: jupyter notebook --config jupyter_notebook_config.py --allow-root
     volumes:
       - .:/code
       - /tmp:/tmp


### PR DESCRIPTION
Allow root to keep Docker notebook from showing location at hash, as observed by @yiyange 