### PR TITLE
[performance] Use v0.11.0 of partridge or greater

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fiona>=1.6.1
 networkx>=2.0
 osmnx>=0.6
-partridge>=0.3.0
+partridge>=0.11.0


### PR DESCRIPTION
Ensures users to do not use older versions of partridge, incl. versions susceptible to performance hits related to https://github.com/remix/partridge/issues/39