### PR TITLE
[simplify] Reduce dependencies in toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ performance/cprof-output.py
 .eggs/
 .pytest_cache/
 profile/
+.coverage-e
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 install:
   - pip install -r requirements.txt
   - pip install -r requirements_dev.txt
+  - pip install osmnx matplotlib
 
 script:
   - PYTHONPATH=. MPLBACKEND="agg" py.test -k 'not graph_tool' --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_install:
 install:
   - pip install -r requirements.txt
   - pip install -r requirements_dev.txt
-  - pip install osmnx matplotlib
 
 script:
   - PYTHONPATH=. MPLBACKEND="agg" py.test -k 'not graph_tool' --verbose

--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -244,12 +244,12 @@ def make_synthetic_system_network(
 
     # Now, iterate through each line, extracting a single SyntheticTransitLine
     for line in new_network.all_lines():
-        nodes = line.get_nodes()
-        edges = line.get_edges()
+        nodes = line.nodes
+        edges = line.edges
 
         # Mutates the G network object
         sid_lookup_sub = _add_nodes_and_edges(
-            G, name, nodes, edges, line.is_bidrectional())
+            G, name, nodes, edges, line.bidirectional)
 
         # Update the parent sid with new values
         for key, val in sid_lookup_sub.items():

--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -243,7 +243,7 @@ def make_synthetic_system_network(
     new_network = SyntheticTransitNetwork(reference_geojson)
 
     # Now, iterate through each line, extracting a single SyntheticTransitLine
-    for line in new_network.all_lines():
+    for line in new_network.lines:
         nodes = line.nodes
         edges = line.edges
 

--- a/peartree/paths.py
+++ b/peartree/paths.py
@@ -21,7 +21,28 @@ class InvalidTimeBracket(Exception):
 
 
 def get_representative_feed(file_loc: str,
-                            day_type: str='busiest'):
+                            day_type: str='busiest') -> ptg.feed:
+    """
+    Given a filepath, extract a partridge feed object, holding a representative
+    set of schedule patterns, extracted from the GTFS zip file, as a set of
+    pandas DataFrames.
+
+    Parameters
+    ----------
+    file_loc : str
+        The location (filepath) of the GTFS zip file.
+    day_type : str
+        The name of the type of representative feed desired. Currently, only
+        one type is supported, busiest. This extracts the schedule pattern
+        for a day that has the most service on it. This is determined by the
+        day with the most trips on it.
+
+    Returns
+    -------
+    feed : ptg.feed
+        A partridge feed object, holding related schedule information as pandas
+        DataFrames for the busiest day in the available schedule.
+    """
     # Extract service ids and then trip counts by those dates
     service_ids_by_date = ptg.read_service_ids_by_date(file_loc)
     trip_counts_by_date = ptg.read_trip_counts_by_date(file_loc)
@@ -64,8 +85,8 @@ def load_feed_as_graph(feed: ptg.gtfs.feed,
                        impute_walk_transfers: bool=False,
                        use_multiprocessing: bool=False):
     """
-    Convert a feed object into a NetworkX Graph, connect to an existing
-    NetworkX graph if one is supplied
+    Convert a feed object into a NetworkX Graph, or connect to an existing
+    NetworkX graph if one is supplied.
 
     Parameters
     ----------

--- a/peartree/plot.py
+++ b/peartree/plot.py
@@ -2,14 +2,24 @@ import os
 
 import networkx as nx
 
+from .utilities import log
+
 
 def generate_plot(G: nx.MultiDiGraph, use_agg=False):
     # Load matplotlib only when plot requested
-    import osmnx as ox  # noqa
     import matplotlib  # noqa
     if use_agg:
         # Force matplotlib to not use any Xwindows backend
         matplotlib.use('Agg')
+
+    # OSMnx is not a dependency anymore, so we should only allow the plot
+    # function to work as a convenience, if the user has already installed
+    # OSMnx
+    try:
+        import osmnx as ox  # noqa
+    except ModuleNotFoundError:
+        log(('Optional dependency: OSMnx must be installed to use the '
+             'plot method in peartree'))
 
     # TODO: Build out custom plotting configurations but,
     #       in the meantime, use OSMnx's plotting configurations

--- a/peartree/plot.py
+++ b/peartree/plot.py
@@ -1,11 +1,11 @@
 import os
 
 import networkx as nx
-import osmnx as ox
 
 
 def generate_plot(G: nx.MultiDiGraph, use_agg=False):
     # Load matplotlib only when plot requested
+    import osmnx as ox  # noqa
     import matplotlib  # noqa
     if use_agg:
         # Force matplotlib to not use any Xwindows backend

--- a/peartree/synthetic.py
+++ b/peartree/synthetic.py
@@ -290,17 +290,19 @@ class SyntheticTransitNetwork(abc.ABC):
 
     def __init__(self, feature_collection: Dict[str, Any]):
         # Initialize an empty list
-        self.lines = []
+        self._lines = []
 
         # For each Feature in the FeatureCollection group; add an additional
         # instantiated SyntheticTransitLine object
         for feature in feature_collection['features']:
             new_line = SyntheticTransitLine(feature)
-            self.lines.append(new_line)
+            self._lines.append(new_line)
 
     def _create_all_lines_generator(self):
-        for line in self.lines:
+        for line in self._lines:
             yield line
 
-    def all_lines(self) -> Iterable[SyntheticTransitLine]:
+    def get_all_lines(self) -> Iterable[SyntheticTransitLine]:
         return self._create_all_lines_generator()
+
+    lines = property(get_all_lines)

--- a/peartree/synthetic.py
+++ b/peartree/synthetic.py
@@ -35,7 +35,6 @@ def generate_meter_projected_chunks(
     # target stops or "break points" for the route line shape
 
     # Path 1 if available
-    print("custom_stopscustom_stops, custom_stops", custom_stops)
     if custom_stops is not None:
         mp_array = []
         for custom_stop in custom_stops:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fiona>=1.6.1
+geopandas>=0.4.0
 networkx>=2.0
 partridge>=0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 fiona>=1.6.1
 networkx>=2.0
-osmnx>=0.6
 partridge>=0.11.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,8 @@ flake8
 coverage
 pytest
 pytest-runner
+matplotlib
+osmnx
 jupyter>=1.0.0
 jupyter-client>=5.1.0
 jupyter-console>=5.2.0

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ with open('peartree/__version__.py', 'r', encoding='utf-8') as f:
 
 requirements = [
     'fiona>=1.6.1',
+    'geopandas>=0.4.0',
     'networkx>=2.0',
     'partridge>=0.3.0'
 ]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ with open('peartree/__version__.py', 'r', encoding='utf-8') as f:
 requirements = [
     'fiona>=1.6.1',
     'networkx>=2.0',
-    'osmnx>=0.6',
     'partridge>=0.3.0'
 ]
 


### PR DESCRIPTION
Toolkit utilizes (part of) OSMnx's simplify graph step. This and the plot method are the only two steps that utilize OSMnx. Due to OSMnx's large array of capabilities, I'm opting to simply copy over the contents of the simplify graph method with minor modification (and full citation/reference to source material) into the peartree repo to attempt to reduce dependencies.