### PR TITLE
[feature] Enable customized wait time estimation

### DIFF
--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -82,6 +82,10 @@ def generate_summary_graph_elements(
         specific route. This can happen when there is only one arrival in \
         the considered time frame. In such situations, the fallback value \
         is used in lieu of a calculated standard wait time for that stop node.
+    stop_cost_method : Any
+        A method is passed in here that handles an arrival time numpy array
+        and, from that array, calcualtes a representative average wait time
+        value, in seconds, for that stop.
     use_multiprocessing : bool
         This is a flag to tell the peartree model whether to attempt to \
         parallelize the computing of route-stop average wait times. It can \

--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Tuple, Union
 
 import networkx as nx
 import pandas as pd
@@ -44,12 +44,61 @@ def nameify_stop_id(name, sid):
     return '{}_{}'.format(name, sid)
 
 
-def generate_summary_graph_elements(feed: ptg.gtfs.feed,
-                                    target_time_start: int,
-                                    target_time_end: int,
-                                    fallback_stop_cost: float,
-                                    interpolate_times: bool,
-                                    use_multiprocessing: bool):
+def generate_summary_graph_elements(
+        feed: ptg.feed,
+        target_time_start: float,
+        target_time_end: float,
+        fallback_stop_cost: float,
+        interpolate_times: bool,
+        use_multiprocessing: bool) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Takes in a feed with a series of settings and produces two results: \
+    a table of edge costs and a table of stop (or nodes).
+
+    Output tables represent the two primary components of a network graph: \
+    the graph nodes and vertices. This method wraps the primary edge and wait \
+    times generator with a few additional validation checks and summary steps.
+
+    Parameters
+    ———————
+    feed : ptg.feed
+        A partridge feed object, holding related schedule information as pandas
+        DataFrames for the busiest day in the available schedule.
+    target_time_start : float
+        Start time in hours (on a 24-hour range). This will be used to \
+        determine what part of the available selected schedule to subselect. \
+        For example, you could set 7.5, which would be read as 7.5 hours past \
+        midnight and converted into seconds.
+    target_time_end : float
+        End time in hours (on a 24-hour range). This will be used to \
+        determine what part of the available selected schedule to subselect. \
+        For example, you could set 13.5, which would be read as 17.5 hours \
+        past midnight and converted into seconds.
+    fallback_stop_cost : float
+        This is measured in seconds. So, if the value is 600, it will equate \
+        to a 10 minute fallback cost. The fallback stop cost is used if \
+        peartree is unable to determine a time between arrivals for a \
+        specific route. This can happen when there is only one arrival in \
+        the considered time frame. In such situations, the fallback value \
+        is used in lieu of a calculated standard wait time for that stop node.
+    use_multiprocessing : bool
+        This is a flag to tell the peartree model whether to attempt to \
+        parallelize the computing of route-stop average wait times. It can \
+        be helpful in speeding up evaluation of larger GTFS feeds.
+
+
+    Returns
+    ——
+    summary_edge_costs : pd.DataFrame
+        The edge DataFrame holds the from and to node (stop) ids, as well \
+        as the cost calculated for traversing that edge.
+    wait_times_by_stop : pd.DataFrame
+        The node, or stops, DataFrame, holds the the stop id and the average \
+        boarding cost for that node (calculated based on the distribution of \
+        arrival times) within the evaluation time range for the target subset \
+        of the feed schedule.
+    """
+
     (all_edge_costs,
      all_wait_times) = generate_edge_and_wait_values(feed,
                                                      target_time_start,
@@ -196,7 +245,7 @@ def _add_nodes_and_edges(G: nx.MultiDiGraph,
 
 def populate_graph(G: nx.MultiDiGraph,
                    name: str,
-                   feed: ptg.gtfs.feed,
+                   feed: ptg.feed,
                    wait_times_by_stop: pd.DataFrame,
                    summary_edge_costs: pd.DataFrame,
                    connection_threshold: Union[int, float],

--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import networkx as nx
 import pandas as pd
@@ -50,6 +50,7 @@ def generate_summary_graph_elements(
         target_time_end: float,
         fallback_stop_cost: float,
         interpolate_times: bool,
+        stop_cost_method: Any,
         use_multiprocessing: bool) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """
     Takes in a feed with a series of settings and produces two results: \
@@ -100,11 +101,13 @@ def generate_summary_graph_elements(
     """
 
     (all_edge_costs,
-     all_wait_times) = generate_edge_and_wait_values(feed,
-                                                     target_time_start,
-                                                     target_time_end,
-                                                     interpolate_times,
-                                                     use_multiprocessing)
+     all_wait_times) = generate_edge_and_wait_values(
+        feed,
+        target_time_start,
+        target_time_end,
+        interpolate_times,
+        stop_cost_method,
+        use_multiprocessing)
 
     # Same sanity checks on the output before we continue
     _verify_outputs(all_edge_costs, all_wait_times)

--- a/peartree/parallel.py
+++ b/peartree/parallel.py
@@ -1,5 +1,5 @@
 from multiprocessing.managers import BaseManager
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 import numpy as np
 import pandas as pd
@@ -19,7 +19,8 @@ class RouteProcessor(object):
             target_time_end: int,
             feed_trips: pd.DataFrame,
             stop_times: pd.DataFrame,
-            all_stops: pd.DataFrame):
+            all_stops: pd.DataFrame,
+            stop_cost_method: Any):
 
         # Initialize common parameters
         self.target_time_start = target_time_start
@@ -34,6 +35,10 @@ class RouteProcessor(object):
         astops = all_stops.copy()
         astops['stop_id'] = astops['stop_id'].astype(str)
         self.all_stops = astops
+
+        # This is a custom method for calculating custom wait time from
+        # a list of arrival time values in a numpy array
+        self.stop_cost_method = stop_cost_method
 
     def generate_route_costs(self, route_id: str):
         # Get all the subset of trips that are related to this route
@@ -86,7 +91,8 @@ class RouteProcessor(object):
                 # If it has no full coverage in direction_id, drop the column
                 trips_and_stop_times.drop('direction_id', axis=1, inplace=True)
 
-        wait_times = generate_wait_times(trips_and_stop_times)
+        wait_times = generate_wait_times(
+            trips_and_stop_times, self.stop_cost_method)
 
         # Used in the next two steps
         stop_id_col = trips_and_stop_times['stop_id'].copy()
@@ -108,26 +114,9 @@ class RouteProcessor(object):
         return (tst_sub, edge_costs)
 
 
-def calculate_average_wait(direction_times: pd.DataFrame) -> float:
-    # Exit early if we do not have enough values to calculate a mean
-    at = direction_times.arrival_time
-    if len(at) < 2:
-        return np.nan
-
-    first = at[1:].values
-    second = at[:-1].values
-    wait_seconds = (first - second)
-
-    # TODO: Can implement something more substantial here that takes into
-    #       account divergent/erratic performance or intentional timing
-    #       clusters that are not evenly dispersed
-    na = np.array(wait_seconds)
-    average_wait = na.mean() / 2  # half headway
-    return average_wait
-
-
-def generate_wait_times(trips_and_stop_times: pd.DataFrame
-                        ) -> Dict[int, List[float]]:
+def generate_wait_times(
+        trips_and_stop_times: pd.DataFrame,
+        stop_cost_method: Any) -> Dict[int, List[float]]:
     wait_times = {0: {}, 1: {}}
     for stop_id in trips_and_stop_times.stop_id.unique():
         # Handle both inbound and outbound directions
@@ -146,7 +135,7 @@ def generate_wait_times(trips_and_stop_times: pd.DataFrame
                 # values associated with the specified direction so default NaN
                 average_wait = np.nan
             else:
-                average_wait = calculate_average_wait(direction_subset)
+                average_wait = stop_cost_method(direction_subset)
 
             # Add according to which direction we are working with
             wait_times[direction][stop_id] = average_wait

--- a/peartree/parallel.py
+++ b/peartree/parallel.py
@@ -88,11 +88,14 @@ class RouteProcessor(object):
 
         wait_times = generate_wait_times(trips_and_stop_times)
 
+        # Used in the next two steps
+        stop_id_col = trips_and_stop_times['stop_id'].copy()
+
         # Look up wait time for each stop in wait_times for each direction
-        wait_zero = trips_and_stop_times['stop_id'].apply(lambda x: wait_times[0][x])
+        wait_zero = stop_id_col.apply(lambda x: wait_times[0][x])
         trips_and_stop_times['wait_dir_0'] = wait_zero
         
-        wait_one = trips_and_stop_times['stop_id'].apply(lambda x: wait_times[1][x])
+        wait_one = stop_id_col.apply(lambda x: wait_times[1][x])
         trips_and_stop_times['wait_dir_1'] = wait_one
 
         tst_sub = trips_and_stop_times[['stop_id',
@@ -138,9 +141,9 @@ def generate_wait_times(trips_and_stop_times: pd.DataFrame
             else:
                 direction_subset = trips_and_stop_times.copy()
 
-            # Only run if each direction is contained
-            # in the same trip id
             if direction_subset.empty:
+                # Cannot calculate the average wait time if there are no
+                # values associated with the specified direction so default NaN
                 average_wait = np.nan
             else:
                 average_wait = calculate_average_wait(direction_subset)

--- a/peartree/parallel.py
+++ b/peartree/parallel.py
@@ -135,7 +135,7 @@ def generate_wait_times(
                 # values associated with the specified direction so default NaN
                 average_wait = np.nan
             else:
-                average_wait = stop_cost_method(direction_subset)
+                average_wait = stop_cost_method(direction_subset.arrival_time)
 
             # Add according to which direction we are working with
             wait_times[direction][stop_id] = average_wait

--- a/peartree/paths.py
+++ b/peartree/paths.py
@@ -185,6 +185,7 @@ def load_feed_as_graph(feed: ptg.feed,
                                                            end_time,
                                                            fallback_stop_cost,
                                                            interpolate_times,
+                                                           stop_cost_method,
                                                            use_multiprocessing)
 
     # This is a flag used to check if we need to run any additional steps

--- a/peartree/paths.py
+++ b/peartree/paths.py
@@ -21,7 +21,7 @@ class InvalidTimeBracket(Exception):
     pass
 
 
-def _calculate_means_default(arrival_times: np.array) -> foo:
+def _calculate_means_default(arrival_times: np.array) -> float:
     # This is the default method that is provided to the load feed operation
     # and applied to the observed arrival times at a given stop. From this
     # array of arrival times, the average delay between stops is calcualted

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -1,6 +1,6 @@
 import multiprocessing as mp
 import time
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -253,6 +253,7 @@ def _generate_route_processing_results(
         ftrips: pd.DataFrame,
         stop_times: pd.DataFrame,
         feed_stops: pd.DataFrame,
+        stop_cost_method: Any,
         use_multiprocessing: bool) -> Tuple[pd.DataFrame, pd.DataFrame]:
     # Track the runtime of this method
     start_time = time.time()
@@ -268,7 +269,8 @@ def _generate_route_processing_results(
             target_time_end,
             ftrips,
             stop_times,
-            feed_stops)
+            feed_stops,
+            stop_cost_method)
 
         with mp.Pool(processes=cpu_count) as pool:
             results = pool.starmap(_route_analyzer_pool_map,
@@ -281,7 +283,8 @@ def _generate_route_processing_results(
             target_time_end,
             ftrips,
             stop_times,
-            feed_stops)
+            feed_stops,
+            stop_cost_method)
         results = [route_analyzer.generate_route_costs(rid)
                    for rid in target_route_ids]
     elapsed = round(time.time() - start_time, 2)
@@ -346,6 +349,7 @@ def generate_edge_and_wait_values(
         target_time_start: int,
         target_time_end: int,
         interpolate_times: bool,
+        stop_cost_method: Any,
         use_multiprocessing: bool) -> Tuple[pd.DataFrame]:
     sub_stop_times = _trim_stop_times_by_timeframe(
         feed.stop_times, target_time_start, target_time_end)
@@ -374,6 +378,7 @@ def generate_edge_and_wait_values(
         ftrips,
         stop_times,
         feed.stops.copy(),
+        stop_cost_method,
         use_multiprocessing)
 
     return (all_edge_costs, all_wait_times)

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -27,24 +27,6 @@ def _format_summarized_outputs(summarized: pd.Series) -> pd.DataFrame:
         'avg_cost': original_series_values})
 
 
-def calculate_average_wait(direction_times: pd.DataFrame) -> float:
-    # Exit early if we do not have enough values to calculate a mean
-    at = direction_times.arrival_time
-    if len(at) < 2:
-        return np.nan
-
-    first = at[1:].values
-    second = at[:-1].values
-    wait_seconds = (first - second)
-
-    # TODO: Can implement something more substantial here that takes into
-    #       account divergent/erratic performance or intentional timing
-    #       clusters that are not evenly dispersed
-    na = np.array(wait_seconds)
-    average_wait = na.mean()
-    return average_wait
-
-
 def summarize_edge_costs(df: pd.DataFrame) -> pd.DataFrame:
     # Used as a function applied to a grouping
     # operation, pulls out the mean edge cost for each
@@ -72,7 +54,7 @@ def generate_summary_edge_costs(all_edge_costs: pd.DataFrame) -> pd.DataFrame:
 def summarize_waits_at_one_stop(stop_df: pd.DataFrame) -> float:
     # Calculates average wait time at this stop, given all observed
     # TODO: Simply dividiing by two may not be appropriate - it is
-    #       go for estimation purposes, but I could introduce
+    #       good for estimation purposes, but I could introduce
     #       more sophisticated wait time calculations here
     divide_by = (len(stop_df) * 2)
     dir_0_sum = stop_df.wait_dir_0.sum()
@@ -360,7 +342,7 @@ def _trim_stop_times_by_timeframe(
 
 
 def generate_edge_and_wait_values(
-        feed: ptg.gtfs.feed,
+        feed: ptg.feed,
         target_time_start: int,
         target_time_end: int,
         interpolate_times: bool,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -3,7 +3,9 @@ import pytest
 
 from peartree.graph import (generate_empty_md_graph,
                             generate_summary_graph_elements)
-from peartree.paths import FALLBACK_STOP_COST_DEFAULT, get_representative_feed
+from peartree.paths import (FALLBACK_STOP_COST_DEFAULT,
+                            _calculate_means_default,
+                            get_representative_feed)
 
 
 def fixture(filename):
@@ -33,6 +35,7 @@ def test_generate_summary_graph_elements():
             end,
             FALLBACK_STOP_COST_DEFAULT,
             interpolate_times,
+            _calculate_means_default,
             use_multiprocessing)
 
         # Ensure that the summary edge cost dataframe looks as it should

--- a/tests/test_graph_assembly.py
+++ b/tests/test_graph_assembly.py
@@ -2,7 +2,9 @@ import os
 from time import time
 
 from peartree.graph import generate_empty_md_graph, populate_graph
-from peartree.paths import FALLBACK_STOP_COST_DEFAULT, get_representative_feed
+from peartree.paths import (FALLBACK_STOP_COST_DEFAULT,
+                            _calculate_means_default,
+                            get_representative_feed)
 from peartree.summarizer import (generate_edge_and_wait_values,
                                  generate_summary_edge_costs,
                                  generate_summary_wait_times)
@@ -38,6 +40,7 @@ def test_feed_to_graph_performance():
                                                      start,
                                                      end,
                                                      interpolate_times,
+                                                     _calculate_means_default,
                                                      use_multiprocessing)
     elapsed = round(time() - a, 2)
     print('Perf of generate_edge_and_wait_values: {}s'.format(elapsed))

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -59,7 +59,7 @@ def test_extract_valid_feed():
     # other optional arguments
     path = fixture('caltrain-2017-07-24.zip')
     feed = get_representative_feed(path)
-    assert isinstance(feed, ptg.gtfs.feed)
+    assert isinstance(feed, ptg.feed)
 
 
 def test_loading_in_too_small_timeframes():


### PR DESCRIPTION
Fixes https://github.com/kuanb/peartree/issues/109

A user can now pass in a custom method for handling wait time. The default is set in paths under `_calculate_means_default`. A user could supply, say, a more optimistic operation to select the shortest delay between stops, or to note multimodal arrival distributions and account for them when determining edge cost.