### PR TITLE
[coalesce] Use mean of grouped edge weights rather than minimum

### DIFF
--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -280,6 +280,7 @@ def coalesce(G_orig: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
         'fr': replacement_edges_fr,
         'to': replacement_edges_to,
         'len': replacement_edges_len})
+    print(edges_df)
 
     # Next we group by the edge pattern (from -> to)
     grouped = edges_df.groupby(['fr', 'to'], sort=False)
@@ -292,26 +293,28 @@ def coalesce(G_orig: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
     edges_to_add = []
     for n1, n2, edge in G.edges(data=True):
         # Get corresponding ids of new nodes (grid corners)
-        rn1 = reference[n1]
-        rn2 = reference[n2]
+        ref_n1 = reference[n1]
+        ref_n2 = reference[n2]
 
         # Retrieve pair value from previous grouping operation
-        avg_length = avg_edges.loc[rn1, rn2]
+        avg_length = avg_edges.loc[ref_n1, ref_n2]
         edges_to_add.append((
-            rn1,
-            rn2,
+            ref_n1,
+            ref_n2,
             avg_length,
             edge['mode']))
 
     # Add the new edges to graph
     for n1, n2, length, mode in edges_to_add:
         # Only add edge if it has not yet been added yet
-        if G.has_edge(rn1, rn2):
+        if G.has_edge(n1, n2):
             continue
 
-        # But avoid edges that now connect to the same node
-        if not n1 == n2:
-            G.add_edge(n1, n2, length=length, mode=mode)
+        # Also avoid edges that now connect to the same node
+        if n1 == n2:
+            continue
+
+        G.add_edge(n1, n2, length=length, mode=mode)
 
     # Now we can remove all edges and nodes that predated the
     # coalescing operations

--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -286,7 +286,6 @@ def coalesce(G_orig: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
 
     # Second step; which uses results from edge_df grouping/parsing
     edges_to_add = []
-    # Go through each edge
     for n1, n2, edge in G.edges(data=True):
         # Get corresponding ids of new nodes (grid corners)
         rn1 = reference[n1]
@@ -305,6 +304,7 @@ def coalesce(G_orig: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
             #       encountered that has not been added.
             #       one can imagine that some modes will be dropped
             #       if coalesce is applied on graph with multiple modes
+            # TODO: segment coalesce by mode
             mode = edge['mode']
             edges_to_add.append((rn1, rn2, length, mode))
 

--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -295,10 +295,6 @@ def coalesce(G_orig: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
         rn1 = reference[n1]
         rn2 = reference[n2]
 
-        # Only add edge if it has not yet been added yet
-        if G.has_edge(rn1, rn2):
-            continue
-
         # Retrieve pair value from previous grouping operation
         avg_length = avg_edges.loc[rn1, rn2]
         edges_to_add.append((
@@ -309,6 +305,10 @@ def coalesce(G_orig: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
 
     # Add the new edges to graph
     for n1, n2, length, mode in edges_to_add:
+        # Only add edge if it has not yet been added yet
+        if G.has_edge(rn1, rn2):
+            continue
+
         # But avoid edges that now connect to the same node
         if not n1 == n2:
             G.add_edge(n1, n2, length=length, mode=mode)

--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -282,7 +282,7 @@ def coalesce(G_orig: nx.MultiDiGraph, resolution: float) -> nx.MultiDiGraph:
     # Next we group by the edge pattern (from -> to)
     grouped = edges_df.groupby(['fr', 'to'], sort=False)
     # With the resulting groupings, we extract values
-    min_edges = grouped['len'].min()
+    min_edges = grouped['len'].mean()
 
     # Second step; which uses results from edge_df grouping/parsing
     edges_to_add = []

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -75,14 +75,15 @@ def test_coalesce_operation():
     G.add_edge('a', 'b_alt', length=100, mode='transit')
 
     # Also add a second edge between the same nodes, but with smaller weight
-    G.add_edge('a', 'b_alt', length=10, mode='transit')
+    # so, it will get tossed in the cleanup
+    G.add_edge('a', 'b_alt', length=50, mode='transit')
 
     G2 = reproject(G)
     G2c = coalesce(G2, 200)
 
     # Same akward situation as before, where edges are returned in
     # different order between Py 3.5 and 3.6
-    for i, node in G2c.nodes(data=True):
+    for _, node in G2c.nodes(data=True):
         a = _dict_equal(node, {
             'x': -1933000,
             'y': -543000,

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -70,15 +70,11 @@ def test_coalesce_operation():
     G.add_edge('b', 'c', length=1, mode='walk')
 
     # Also add a node, and edge that is a more expensive variant
-    # of effectively the same edge to make sure this more expensive edge
-    # gets tossed during the coalesce
+    # of effectively the same edge
     G.add_node('b_alt', x=-122.2711039, y=37.7660709, boarding_cost=13.5)
     G.add_edge('a', 'b_alt', length=100, mode='transit')
 
-    # Also add a second edge between the same nodes, but with an equal weight
-    G.add_edge('a', 'b_alt', length=100, mode='transit')
-
-    # Add a node that won't be preserved (no edges connected to it)
+    # Also add a second edge between the same nodes, but with smaller weight
     G.add_edge('a', 'b_alt', length=10, mode='transit')
 
     G2 = reproject(G)
@@ -101,7 +97,7 @@ def test_coalesce_operation():
     assert len(all_edges) == 1
 
     # Make sure that the one edge came out as expected
-    assert _dict_equal(all_edges[0][2], {'length': 10, 'mode': 'transit'})
+    assert _dict_equal(all_edges[0][2], {'length': 55, 'mode': 'transit'})
 
 
 def test_simplify_graph():


### PR DESCRIPTION
Using minimum of grouped edge weights effectively reduce path costs, and increase accessibility significantly.
The following map shows shortest path lengths from one single source to all destinations in Berkeley.
It changes from using original full network to coalesced network using min grouped edge weights. Noticing the shortest path lengths reduce significantly (darker color to lighter color)
![use_min](https://user-images.githubusercontent.com/14876272/52310060-ef495e80-2956-11e9-88db-fe4aebd2e11a.gif)

The following map shows the same change but using coalesced network using mean (different color bins though). The change is less significant. 
![use_mean](https://user-images.githubusercontent.com/14876272/52319668-da34f580-297f-11e9-9a7c-44dc5cea2bb0.gif)


Also some stats comparison:

**Stats** | **Full Network** | **Coalesced w Min** | **Coalesced w Mean**
--|--|--|--
Max shortest path length | 5172 | 3092 | 3493
Mean shortest path length | 2488 | 1383 | 1619

Visuals made by UrbanFootprint :))