### PR TITLE
[coalesce] Parameterize summary operations

### DIFF
--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -263,7 +263,7 @@ def coalesce(
             bc = G.nodes[i]['boarding_cost']
             boarding_costs.append(bc)
 
-        # Calculate the mean of the boarding costs
+        # Calculate the summary boarding costs
         # and assign it to the new nodes objects
         new_node_coords[nni]['boarding_cost'] = (
             edge_summary_method(np.array(boarding_costs)))
@@ -284,7 +284,6 @@ def coalesce(
         'fr': replacement_edges_fr,
         'to': replacement_edges_to,
         'len': replacement_edges_len})
-    print(edges_df)
 
     # Next we group by the edge pattern (from -> to)
     grouped = edges_df.groupby(['fr', 'to'], sort=False)

--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -266,7 +266,7 @@ def coalesce(
         # Calculate the summary boarding costs
         # and assign it to the new nodes objects
         new_node_coords[nni]['boarding_cost'] = (
-            edge_summary_method(np.array(boarding_costs)))
+            boarding_cost_summary_method(np.array(boarding_costs)))
 
     # First step to creating a list of replacement edges
     replacement_edges_fr = []
@@ -290,7 +290,7 @@ def coalesce(
 
     # With the resulting groupings, we extract values
     # TODO: Also group on modes
-    processed_edge_costs = boarding_cost_summary_method(grouped['len'])
+    processed_edge_costs = edge_summary_method(grouped['len'])
 
     # Second step; which uses results from edge_df grouping/parsing
     edges_to_add = []

--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -264,10 +264,9 @@ def coalesce(
             boarding_costs.append(bc)
 
         # Calculate the mean of the boarding costs
-        avg_bc = edge_summary_method(np.array(boarding_costs))
-
-        # And assign it to the new nodes objects
-        new_node_coords[nni]['boarding_cost'] = avg_bc
+        # and assign it to the new nodes objects
+        new_node_coords[nni]['boarding_cost'] = (
+            edge_summary_method(np.array(boarding_costs)))
 
     # First step to creating a list of replacement edges
     replacement_edges_fr = []


### PR DESCRIPTION
1. Create defaults for boarding cost and edge cost summarizers, both separate from the other.
2. Update tests to ensure edge cost summarizer performing as intended.