### PR TITLE
[wait_time_estimation] Trim zeroes in default wait time estimation

### DIFF
--- a/peartree/paths.py
+++ b/peartree/paths.py
@@ -39,8 +39,7 @@ def _calculate_means_default(arrival_times: np.array) -> float:
     #       would replace this default method
     na = np.array(wait_seconds)
 
-    # Prune all 0-wait times as we want this will overweight to low
-    # wait time estimates
+    # Prune 0-second delays as these excessively reduce wait-time estimates
     na_no_zeroes = na[na > 0]
 
     # Naive implementation: halve the headway to get average wait time

--- a/peartree/paths.py
+++ b/peartree/paths.py
@@ -39,8 +39,10 @@ def _calculate_means_default(arrival_times: np.array) -> float:
     #       would replace this default method
     na = np.array(wait_seconds)
 
+    na_no_zeroes = na[na > 0]
+
     # Naive implementation: halve the headway to get average wait time
-    average_wait = na.mean() / 2
+    average_wait = na_no_zeroes.mean() / 2
     return average_wait
 
 

--- a/peartree/paths.py
+++ b/peartree/paths.py
@@ -39,6 +39,8 @@ def _calculate_means_default(arrival_times: np.array) -> float:
     #       would replace this default method
     na = np.array(wait_seconds)
 
+    # Prune all 0-wait times as we want this will overweight to low
+    # wait time estimates
     na_no_zeroes = na[na > 0]
 
     # Naive implementation: halve the headway to get average wait time

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -60,7 +60,8 @@ def test_generate_summary_graph_elements():
         assert len(wait_times_by_stop[mask]) == 0
 
         # Just a heuristic for avg_cost mean
-        assert wait_times_by_stop.avg_cost.mean() == pytest.approx(1015.6, abs=0.1)
+        avg_cost_mean = wait_times_by_stop.avg_cost.mean()
+        assert avg_cost_mean == pytest.approx(1109.380, abs=0.1)
 
         # Make sure that there are stop ids unique
         u = wait_times_by_stop.stop_id.unique()


### PR DESCRIPTION
Fixes https://github.com/kuanb/peartree/issues/133