### PR TITLE
Lock to v1.0.0 on partridge

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
     'fiona>=1.6.1',
     'geopandas>=0.4.0',
     'networkx>=2.0',
-    'partridge>=1.0.0'
+    'partridge==1.0.0'
 ]
 
 setup_requirements = [


### PR DESCRIPTION
Lock to v1.0.0 on partridge dependency
Why? Since 1.1 has breaking changes

Do this until I update how Feed class is handled; then can update to 1.1