### PR TITLE
Do not prune trips with just one arrival time

### DIFF
--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -147,19 +147,7 @@ def generate_summary_wait_times(
     df_sub = df[['stop_id',
                  'wait_dir_0',
                  'wait_dir_1']].reset_index(drop=True)
-
-    # Get the number of wait time rows registered with each unique stop
-    stop_id_vcs = df_sub['stop_id'].value_counts()
-
-    # Find the rows with just 1 entry that are nan and
-    # assign those the default fallback stop cost value
-    mask_is_one = stop_id_vcs == 1
-    sub_stop_id_vcs = stop_id_vcs[mask_is_one]
-    over_zero_mask = sub_stop_id_vcs > 0
-    sub_stop_id_vcs[~over_zero_mask] = fallback_stop_cost
-
-    # Also use this Series to extract the number of unique stop ids
-    init_of_stop_ids = stop_id_vcs.index
+    init_of_stop_ids = df_sub['stop_id'].unique()
 
     # Default values for average waits with not enough data should be
     # NaN types, but let's make sure all null types are NaNs to be safe

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -147,7 +147,19 @@ def generate_summary_wait_times(
     df_sub = df[['stop_id',
                  'wait_dir_0',
                  'wait_dir_1']].reset_index(drop=True)
-    init_of_stop_ids = df_sub.stop_id.unique()
+
+    # Get the number of wait time rows registered with each unique stop
+    stop_id_vcs = df_sub['stop_id'].value_counts()
+
+    # Find the rows with just 1 entry that are nan and
+    # assign those the default fallback stop cost value
+    mask_is_one = stop_id_vcs == 1
+    sub_stop_id_vcs = stop_id_vcs[mask_is_one]
+    over_zero_mask = sub_stop_id_vcs > 0
+    sub_stop_id_vcs[~over_zero_mask] = fallback_stop_cost
+
+    # Also use this Series to extract the number of unique stop ids
+    init_of_stop_ids = stop_id_vcs.index
 
     # Default values for average waits with not enough data should be
     # NaN types, but let's make sure all null types are NaNs to be safe

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -157,7 +157,8 @@ def generate_summary_wait_times(
 
         # Convert anything that is 0 or less seconds to a NaN as well
         # to remove negative or 0 second waits in the system
-        df_sub.loc[~(df_sub[col] > 0), col] = np.nan
+        over_zero_mask = df_sub[col] > 0
+        df_sub.loc[~over_zero_mask, col] = np.nan
 
         # With all null types converted to NaN, we can cast col as float
         df_sub[col] = df_sub[col].astype(float)

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pandas as pd
+from peartree.summarizer import generate_summary_wait_times
+
+
+def test_generate_summary_wait_times():
+    df = pd.DataFrame({
+        'stop_id': [
+            1,
+            1,
+            2,
+            2,
+            3,
+            4],
+        'wait_dir_0': [
+            10,
+            10,
+            19,
+            21,
+            np.nan,
+            12],
+        'wait_dir_1': [
+            np.nan,
+            np.nan,
+            9,
+            11,
+            np.nan,
+            np.nan],
+    })
+
+    fallback_stop_cost = 40.0  # seconds
+    res = generate_summary_wait_times(df, fallback_stop_cost)
+    res = res.sort_values(by='stop_id')
+    assert res['stop_id'].tolist() == [1, 2, 3, 4]
+    assert res['avg_cost'].tolist() == [10.0, 15.0, 40.0, 12.0]


### PR DESCRIPTION
When calculating node wait times, do not drop nodes that have just one wait time associated with them. For these, replace with the user-defaulted fallback wait time value.

Fixes https://github.com/kuanb/peartree/issues/139

TODO: Add tests specifically around there being only one stop time associated with that stop wait time estimate.