### PR TITLE
Add logger warning for coalesce function

### DIFF
--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -199,6 +199,10 @@ def coalesce(
     edge_summary_method=lambda x: x.max(),
     boarding_cost_summary_method=lambda x: x.mean(),
 ) -> nx.MultiDiGraph:
+    warnings.warn((
+        'coalesce method is experimental - application risks '
+        'deformation of overall graph structure'))
+
     # Make sure our resolution satisfies basic requirement
     if resolution < 1:
         raise ValueError('Resolution parameters must be >= 1')

--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -199,9 +199,11 @@ def coalesce(
     edge_summary_method=lambda x: x.max(),
     boarding_cost_summary_method=lambda x: x.mean(),
 ) -> nx.MultiDiGraph:
+    # Note: Feature is experimental. For more details, see
+    #       https://github.com/kuanb/peartree/issues/126
     warnings.warn((
-        'coalesce method is experimental - application risks '
-        'deformation of overall graph structure'))
+        'coalesce method is experimental - method risks '
+        'deformation of relative graph structure'))
 
     # Make sure our resolution satisfies basic requirement
     if resolution < 1:


### PR DESCRIPTION
In addition to warning, comment points to https://github.com/kuanb/peartree/issues/126 for more details.

Helps prevent exploratory users from unintentionally undermining their graph through a naive coalesce op.