### PR TITLE
New attribute on stop nodes - modes list

### DIFF
--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -8,7 +8,8 @@ from fiona import crs
 from .settings import WGS84
 from .summarizer import (generate_edge_and_wait_values,
                          generate_summary_edge_costs,
-                         generate_summary_wait_times)
+                         generate_summary_wait_times,
+                         get_modes_at_stops)
 from .synthetic import SyntheticTransitNetwork
 from .toolkit import generate_graph_node_dataframe, get_nearest_nodes
 
@@ -125,6 +126,24 @@ def generate_summary_graph_elements(
                                                      fallback_stop_cost)
 
     return (summary_edge_costs, wait_times_by_stop)
+
+
+def add_modes_to_wait_times(
+        feed: ptg.gtfs.Feed,
+        wait_times_by_stop: pd.DataFrame):
+    # Note: wait_times_by_stop dataframe has 2 columns when passed in:
+    #           stop_id, avg_cost
+    #       stops_modes_lookup will have 2 columns:
+    #           stop_id, modes
+    stops_modes_lookup = get_modes_at_stops(feed)
+
+    # Merge the two onto one dataframe with a total of 3 columns:
+    #       stop_id, avg_cost, modes
+    return pd.merge(
+        wait_times_by_stop,
+        stops_modes_lookup,
+        on='stop_id',
+        how='left')
 
 
 def generate_cross_feed_edges(G: nx.MultiDiGraph,

--- a/peartree/paths.py
+++ b/peartree/paths.py
@@ -4,7 +4,8 @@ import networkx as nx
 import numpy as np
 import partridge as ptg
 
-from .graph import (generate_empty_md_graph, generate_summary_graph_elements,
+from .graph import (add_modes_to_wait_times, generate_empty_md_graph,
+                    generate_summary_graph_elements,
                     make_synthetic_system_network, populate_graph)
 from .synthetic import SyntheticTransitNetwork
 from .toolkit import generate_random_name
@@ -219,6 +220,8 @@ def load_feed_as_graph(feed: ptg.gtfs.Feed,
                                                            stop_cost_method,
                                                            use_multiprocessing)
 
+    stop_attributes = add_modes_to_wait_times(feed, wait_times_by_stop)
+
     # This is a flag used to check if we need to run any additional steps
     # after the feed is returned to ensure that new nodes and edge can connect
     # with existing ones (if they exist/a graph is passed in)
@@ -236,7 +239,7 @@ def load_feed_as_graph(feed: ptg.gtfs.Feed,
     return populate_graph(G,
                           name,
                           feed,
-                          wait_times_by_stop,
+                          stop_attributes,
                           summary_edge_costs,
                           connection_threshold,
                           walk_speed_kmph,

--- a/peartree/paths.py
+++ b/peartree/paths.py
@@ -4,8 +4,7 @@ import networkx as nx
 import numpy as np
 import partridge as ptg
 
-from .graph import (add_modes_to_wait_times, generate_empty_md_graph,
-                    generate_summary_graph_elements,
+from .graph import (generate_empty_md_graph, generate_summary_graph_elements,
                     make_synthetic_system_network, populate_graph)
 from .synthetic import SyntheticTransitNetwork
 from .toolkit import generate_random_name
@@ -220,8 +219,6 @@ def load_feed_as_graph(feed: ptg.gtfs.Feed,
                                                            stop_cost_method,
                                                            use_multiprocessing)
 
-    stop_attributes = add_modes_to_wait_times(feed, wait_times_by_stop)
-
     # This is a flag used to check if we need to run any additional steps
     # after the feed is returned to ensure that new nodes and edge can connect
     # with existing ones (if they exist/a graph is passed in)
@@ -239,7 +236,7 @@ def load_feed_as_graph(feed: ptg.gtfs.Feed,
     return populate_graph(G,
                           name,
                           feed,
-                          stop_attributes,
+                          wait_times_by_stop,
                           summary_edge_costs,
                           connection_threshold,
                           walk_speed_kmph,

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -510,5 +510,8 @@ def get_modes_at_stops(feed: ptg.gtfs.Feed):
     rts_sub = route_trips_stimes[['stop_id', 'route_type']]
     grouped = rts_sub.groupby('stop_id')
 
-    return grouped.apply(lambda x: x[
+    as_series = grouped.apply(lambda x: x[
         'route_type'].unique().astype(str).tolist())
+    as_df = as_series.to_frame().reset_index()
+    as_df.columns = ['stop_id', 'modes']
+    return as_df

--- a/peartree/summarizer.py
+++ b/peartree/summarizer.py
@@ -498,3 +498,17 @@ def generate_edge_and_wait_values(
         use_multiprocessing)
 
     return (all_edge_costs, all_wait_times)
+
+
+def get_modes_at_stops(feed: ptg.gtfs.Feed):
+    route_subset = feed.routes[['route_id', 'route_type']]
+    trips_subset = feed.trips[['trip_id', 'route_id']]
+    route_trips = pd.merge(route_subset, trips_subset, on='route_id')
+
+    stop_times_subset = feed.stop_times[['trip_id', 'stop_id']]
+    route_trips_stimes = pd.merge(route_trips, stop_times_subset, on='trip_id')
+    rts_sub = route_trips_stimes[['stop_id', 'route_type']]
+    grouped = rts_sub.groupby('stop_id')
+
+    return grouped.apply(lambda x: x[
+        'route_type'].unique().astype(str).tolist())

--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -274,6 +274,23 @@ def coalesce(
         new_node_coords[nni]['boarding_cost'] = (
             boarding_cost_summary_method(np.array(boarding_costs)))
 
+    # Get the modes associated with each node grouping
+    for nni in new_node_coords:
+        # Initialize an empty list
+        all_modes_related = []
+
+        # Get all original nodes that have been grouped
+        g_nodes = reference.loc[reference == nni].index.values
+
+        # Iterate through and add gather costs
+        for i in g_nodes:
+            this_nodes_modes = G.nodes[i]['modes']
+            all_modes_related.extend(this_nodes_modes)
+
+        # Get all unique modes and assign it to the new nodes objects
+        sorted_set_list = sorted(list(set(all_modes_related)))
+        new_node_coords[nni]['modes'] = sorted_set_list
+
     # First step to creating a list of replacement edges
     replacement_edges_fr = []
     replacement_edges_to = []

--- a/peartree/utilities.py
+++ b/peartree/utilities.py
@@ -127,7 +127,7 @@ def generate_nodes_df_from_graph(G: nx.MultiDiGraph) -> pd.DataFrame:
     nodes_df = pd.DataFrame(nodes_rows)
 
     # Make sure that the column order is consistent
-    nodes_df = nodes_df[['id', 'boarding_cost', 'modes' 'x', 'y']]
+    nodes_df = nodes_df[['id', 'boarding_cost', 'modes', 'x', 'y']]
     return nodes_df
 
 

--- a/peartree/utilities.py
+++ b/peartree/utilities.py
@@ -119,6 +119,7 @@ def generate_nodes_df_from_graph(G: nx.MultiDiGraph) -> pd.DataFrame:
         nodes_rows.append({
             'id': node_id,
             'boarding_cost': node['boarding_cost'],
+            'modes': node['modes'],
             'x': node['x'],
             'y': node['y']})
 
@@ -126,7 +127,7 @@ def generate_nodes_df_from_graph(G: nx.MultiDiGraph) -> pd.DataFrame:
     nodes_df = pd.DataFrame(nodes_rows)
 
     # Make sure that the column order is consistent
-    nodes_df = nodes_df[['id', 'boarding_cost', 'x', 'y']]
+    nodes_df = nodes_df[['id', 'boarding_cost', 'modes' 'x', 'y']]
     return nodes_df
 
 
@@ -206,6 +207,7 @@ def graph_from_zip(path_to_zip_file: str) -> nx.MultiDiGraph:
     for i, node in nodes_df.iterrows():
         G_from_zip.add_node(node['id'],
                             boarding_cost=node['boarding_cost'],
+                            modes=node['modes'],
                             x=node['x'],
                             y=node['y'])
 

--- a/tests/test_graph_tool.py
+++ b/tests/test_graph_tool.py
@@ -31,7 +31,8 @@ def test_conversion_to_graph_tool():
     assert isinstance(gtG, gt.Graph)
 
     # Also make sure that the attributes for all parameters have been preserved
-    assert set(gtG.vp.keys()) == set(('boarding_cost', 'id', 'x', 'y'))
+    assert set(gtG.vp.keys()) == set((
+        'boarding_cost', 'modes', 'id', 'x', 'y'))
     assert set(gtG.gp.keys()) == set(('crs', 'name'))
     assert set(gtG.ep.keys()) == set(('length', 'mode'))
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -368,3 +368,6 @@ def test_feeds_with_no_direction_id():
     # Make sure each node has numeric boarding cost
     for i, node in G.nodes(data=True):
         assert not np.isnan(node['boarding_cost'])
+
+        # Also check type of the modes list
+        assert not type(node['modes']) == list

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -370,4 +370,4 @@ def test_feeds_with_no_direction_id():
         assert not np.isnan(node['boarding_cost'])
 
         # Also check type of the modes list
-        assert not type(node['modes']) == list
+        assert type(node['modes']) == list

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -85,7 +85,7 @@ def test_coalesce_operation():
                    boarding_cost=15)
         G.add_node('c',
                    x=-122.2711038, y=37.7660708,
-                   modes=['3'],
+                   modes=['1', '3'],
                    boarding_cost=12)
 
         G.add_edge('a', 'b', length=10, mode='transit')
@@ -120,7 +120,7 @@ def test_coalesce_operation():
             ref_node_b = {
                 'x': -1932800,
                 'y': -543400,
-                'modes': ['3'],
+                'modes': ['1', '3'],
                 'boarding_cost': 13.5}
             b = _dict_equal(node, ref_node_b)
 

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -76,11 +76,17 @@ def test_coalesce_operation():
 
         # And add two nodes to it
         G.add_node('a',
-                   x=-122.2729918, y=37.7688136, boarding_cost=10)
+                   x=-122.2729918, y=37.7688136,
+                   modes=['3'],
+                   boarding_cost=10)
         G.add_node('b',
-                   x=-122.2711039, y=37.7660709, boarding_cost=15)
+                   x=-122.2711039, y=37.7660709,
+                   modes=['3'],
+                   boarding_cost=15)
         G.add_node('c',
-                   x=-122.2711038, y=37.7660708, boarding_cost=12)
+                   x=-122.2711038, y=37.7660708,
+                   modes=['3'],
+                   boarding_cost=12)
 
         G.add_edge('a', 'b', length=10, mode='transit')
         G.add_edge('b', 'c', length=1, mode='walk')
@@ -88,7 +94,9 @@ def test_coalesce_operation():
         # Also add a node, and edge that is a more expensive variant
         # of effectively the same edge
         G.add_node('b_alt',
-                   x=-122.2711039, y=37.7660709, boarding_cost=13.5)
+                   x=-122.2711039, y=37.7660709,
+                   modes=['3'],
+                   boarding_cost=13.5)
 
         G.add_edge('a', 'b_alt', length=100, mode='transit')
 
@@ -105,12 +113,14 @@ def test_coalesce_operation():
             ref_node_a = {
                 'x': -1933000,
                 'y': -543000,
+                'modes': ['3'],
                 'boarding_cost': 10.0}
             a = _dict_equal(node, ref_node_a)
 
             ref_node_b = {
                 'x': -1932800,
                 'y': -543400,
+                'modes': ['3'],
                 'boarding_cost': 13.5}
             b = _dict_equal(node, ref_node_b)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -61,7 +61,7 @@ def test_save_and_read_zip():
 
     # Also make sure the basic attributes are preserved
     for node_id, node in G2.nodes(data=True):
-        for key in ['boarding_cost', 'x', 'y']:
+        for key in ['boarding_cost', 'modes', 'x', 'y']:
             assert key in node.keys()
 
     for from_id, to_id, edge in G2.edges(data=True):


### PR DESCRIPTION
Include a list of all modes by GTFS mode id under each node produced for the NetworkX graph.

Fixes https://github.com/kuanb/peartree/issues/150