### PR TITLE
Fix issue 136 - Use pandas.Series.to_numpy().nonzero

### DIFF
--- a/peartree/toolkit.py
+++ b/peartree/toolkit.py
@@ -157,7 +157,7 @@ def nan_helper(y):
         >>> y[nans]= np.interp(x(nans), x(~nans), y[~nans])
     """
 
-    return (np.isnan(y), lambda z: z.nonzero()[0])
+    return (np.isnan(y), lambda z: z.to_numpy().nonzero()[0])
 
 
 def reproject(G: nx.MultiDiGraph, to_epsg: int=2163) -> nx.MultiDiGraph:


### PR DESCRIPTION
Fixes #136 

Update `pandas.Series.nonzero` (deprecated since 0.24.0 https://pandas.pydata.org/pandas-docs/version/0.25.3/reference/api/pandas.Series.nonzero.html) to `pandas.Series.to_numpy().nonzero`