### PR TITLE
Use the same DataFrame in the filter that is being filtered

### DIFF
--- a/peartree/parallel.py
+++ b/peartree/parallel.py
@@ -123,7 +123,7 @@ def generate_wait_times(
         for direction in [0, 1]:
             # Check if direction_id exists in source data
             if 'direction_id' in trips_and_stop_times:
-                constraint_2 = (trips_and_stop_times.direction_id == direction)
+                constraint_2 = (stop_times_by_stop.direction_id == direction)
                 direction_subset = stop_times_by_stop[constraint_2]
             else:
                 direction_subset = stop_times_by_stop.copy()


### PR DESCRIPTION
This is an completely untested proposed fix for https://github.com/kuanb/peartree/issues/165