### PR TITLE
iteritems -> items: Fixing terminal spam

### DIFF
--- a/peartree/graph.py
+++ b/peartree/graph.py
@@ -194,7 +194,7 @@ def generate_cross_feed_edges(G: nx.MultiDiGraph,
                                           exempt_id=full_sid)
 
         # Iterate through series results and add to output
-        for node_id, dist_val in nearest_nodes.iteritems():
+        for node_id, dist_val in nearest_nodes.items():
             stop_ids.append(sid)
             to_nodes.append(node_id)
             edge_costs.append(dist_val)


### PR DESCRIPTION
The library generates the following error, spamming my terminal:
```
/home/user/.local/lib/python3.10/site-packages/peartree/graph.py:197: FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead.
```
This PR fixes this.